### PR TITLE
Specify 'utf-8' encoding when opening temp xml file.

### DIFF
--- a/unshackle/core/utils/tags.py
+++ b/unshackle/core/utils/tags.py
@@ -294,7 +294,7 @@ def _apply_tags(path: Path, tags: dict[str, str]) -> None:
     for name, value in tags.items():
         xml_lines.append(f"    <Simple><Name>{escape(name)}</Name><String>{escape(value)}</String></Simple>")
     xml_lines.extend(["  </Tag>", "</Tags>"])
-    with tempfile.NamedTemporaryFile("w", suffix=".xml", delete=False) as f:
+    with tempfile.NamedTemporaryFile("w", suffix=".xml", delete=False, encoding="utf-8") as f:
         f.write("\n".join(xml_lines))
         tmp_path = Path(f.name)
     try:


### PR DESCRIPTION
This PR fixes UnicodeEncodeErrors when trying to write special characters in the temporary XML file in `_apply_tags()` by explicitly specifying the character encoding to "utf-8". This is useful if you have an episode description that has special unicode characters like "ń" and others.

<img width="733" height="678" alt="image" src="https://github.com/user-attachments/assets/eb523a75-2f6b-4369-8fa0-a8609c7294ff" />
