### PR TITLE
Fix unshackle not finding config in user config dir

### DIFF
--- a/unshackle/core/config.py
+++ b/unshackle/core/config.py
@@ -17,7 +17,7 @@ class Config:
         services = [namespace_dir / "services"]
         vaults = namespace_dir / "vaults"
         fonts = namespace_dir / "fonts"
-        user_configs = core_dir.parent
+        user_configs = Path(app_dirs.user_config_dir)
         data = core_dir.parent
         downloads = core_dir.parent.parent / "downloads"
         temp = core_dir.parent.parent / "temp"


### PR DESCRIPTION
In devine, user_configs was defined as `user_configs = Path(app_dirs.user_config_dir)`. This meant that the config could be stored in `%localappdata%/devine` and in `.config/devine` on Linux (where this is a common convention).

During the fork this was changed to `core_dir.parent` which means it is not possible to store the config in `.config/unshackle`.

I assume that change was unintentional since the `POSSIBLE_CONFIG_PATHS` list lower in the file now contains two redundant entries:

```
Config._Directories.namespace_dir / Config._Filenames.root_config,
[...]
Config._Directories.user_configs / Config._Filenames.root_config,
```

As namespace_dir is also defined as `core_dir.parent`, these evaluate to the same thing.