### PR TITLE
Dash naming seperation feature

### DIFF
--- a/unshackle/core/titles/episode.py
+++ b/unshackle/core/titles/episode.py
@@ -109,13 +109,38 @@ class Episode(Title):
                 name += f" {self.year}"
             name += f" S{self.season:02}"
         else:
-            name = "{title}{year} S{season:02}E{number:02} {name}".format(
-                title=self.title.replace("$", "S"),  # e.g., Arli$$
-                year=f" {self.year}" if self.year and config.series_year else "",
-                season=self.season,
-                number=self.number,
-                name=self.name or "",
-            ).strip()
+            if config.dash_naming:
+                # Format: Title - SXXEXX - Episode Name
+                title_part = self.title.replace("$", "S")  # e.g., Arli$$
+                
+                parts = title_part.rsplit(" ", 1)
+                if len(parts) == 2:
+                    main_title, subtitle = parts
+                    name = f"{main_title} - {subtitle}"
+                else:
+                    name = title_part
+                
+                # Add year if configured
+                if self.year and config.series_year:
+                    name += f" {self.year}"
+                
+                # Add season and episode
+                name += f" S{self.season:02}E{self.number:02}"
+                
+                # Add episode name with dash separator
+                if self.name:
+                    name += f" - {self.name}"
+                
+                name = name.strip()
+            else:
+                # Standard format without extra dashes
+                name = "{title}{year} S{season:02}E{number:02} {name}".format(
+                    title=self.title.replace("$", "S"),  # e.g., Arli$$
+                    year=f" {self.year}" if self.year and config.series_year else "",
+                    season=self.season,
+                    number=self.number,
+                    name=self.name or "",
+                ).strip()
 
         if config.scene_naming:
             # Resolution

--- a/unshackle/core/titles/movie.py
+++ b/unshackle/core/titles/movie.py
@@ -47,6 +47,8 @@ class Movie(Title):
 
     def __str__(self) -> str:
         if self.year:
+            if config.dash_naming:
+                return f"{self.name} - {self.year}"
             return f"{self.name} ({self.year})"
         return self.name
 

--- a/unshackle/unshackle-example.yaml
+++ b/unshackle/unshackle-example.yaml
@@ -20,7 +20,9 @@ set_terminal_bg: false
 # Set file naming convention
 #  true for style - Prime.Suspect.S07E01.The.Final.Act.Part.One.1080p.ITV.WEB-DL.AAC2.0.H.264
 #  false for style - Prime Suspect S07E01 The Final Act - Part One
+#  true for dash separator style - Prime Suspect - S07E01 - The Final Act - Part One
 scene_naming: true
+dash_naming: false
 
 # Whether to include the year in series names for episodes and folders (default: true)
 #  true for style - Show Name (2023) S01E01 Episode Name


### PR DESCRIPTION
Added in for movies.py and epsiode.py a feature that allows the user to toggle on a - (dash) in the naming scheme.
Nothing fancy but nice to have.