### PR TITLE
Fix Missing HLS Curl Session Processing

### DIFF
--- a/unshackle/core/manifests/hls.py
+++ b/unshackle/core/manifests/hls.py
@@ -255,7 +255,7 @@ class HLS:
         else:
             # Get the playlist text and handle both session types
             response = session.get(track.url)
-            if isinstance(response, requests.Response):
+            if isinstance(response, requests.Response) or isinstance(response, CurlResponse):
                 if not response.ok:
                     log.error(f"Failed to request the invariant M3U8 playlist: {response.status_code}")
                     sys.exit(1)
@@ -583,7 +583,7 @@ class HLS:
                         )
 
                         # Check response based on session type
-                        if isinstance(res, requests.Response):
+                        if isinstance(res, requests.Response) or isinstance(res, CurlResponse):
                             res.raise_for_status()
                             init_content = res.content
                         else:


### PR DESCRIPTION
Curl session responsed processing was missing from the HLS stream when the service was using Curl session.

╭───────────────────── Traceback (most recent call last) ──────────────────────╮
│ D:\Program\DRM\unshackle-dev\unshackle\commands\dl.py:1710 in result         │
│                                                                              │
│   1707 │   │   │   │   │   │   │   │   for i, track in enumerate(title.track │
│   1708 │   │   │   │   │   │   │   )                                         │
│   1709 │   │   │   │   │   │   ):                                            │
│ ❱ 1710 │   │   │   │   │   │   │   download.result()                         │
│   1711 │   │   │                                                             │
│   1712 │   │   │   except KeyboardInterrupt:                                 │
│   1713 │   │   │   │   console.print(Padding(":x: Download Cancelled...", (0 │
│                                                                              │
│ C:\Users\...\AppData\Local\Programs\Python\Python311\Lib\concurrent\future │
│ s\_base.py:449 in result                                                     │
│                                                                              │
│   446 │   │   │   │   if self._state in [CANCELLED, CANCELLED_AND_NOTIFIED]: │
│   447 │   │   │   │   │   raise CancelledError()                             │
│   448 │   │   │   │   elif self._state == FINISHED:                          │
│ ❱ 449 │   │   │   │   │   return self.__get_result()                         │
│   450 │   │   │   │                                                          │
│   451 │   │   │   │   self._condition.wait(timeout)                          │
│   452                                                                        │
│                                                                              │
│ C:\Users\...\AppData\Local\Programs\Python\Python311\Lib\concurrent\future │
│ s\_base.py:401 in __get_result                                               │
│                                                                              │
│   398 │   def __get_result(self):                                            │
│   399 │   │   if self._exception:                                            │
│   400 │   │   │   try:                                                       │
│ ❱ 401 │   │   │   │   raise self._exception                                  │
│   402 │   │   │   finally:                                                   │
│   403 │   │   │   │   # Break a reference cycle with the exception in self._ │
│   404 │   │   │   │   self = None                                            │
│                                                                              │
│ C:\Users\...\AppData\Local\Programs\Python\Python311\Lib\concurrent\future │
│ s\thread.py:58 in run                                                        │
│                                                                              │
│    55 │   │   │   return                                                     │
│    56 │   │                                                                  │
│    57 │   │   try:                                                           │
│ ❱  58 │   │   │   result = self.fn(*self.args, **self.kwargs)                │
│    59 │   │   except BaseException as exc:                                   │
│    60 │   │   │   self.future.set_exception(exc)                             │
│    61 │   │   │   # Break a reference cycle with the exception 'exc'         │
│                                                                              │
│ D:\Program\DRM\unshackle-dev\unshackle\core\tracks\track.py:260 in download  │
│                                                                              │
│   257 │   │                                                                  │
│   258 │   │   try:                                                           │
│   259 │   │   │   if self.descriptor == self.Descriptor.HLS:                 │
│ ❱ 260 │   │   │   │   HLS.download_track(                                    │
│   261 │   │   │   │   │   track=self,                                        │
│   262 │   │   │   │   │   save_path=save_path,                               │
│   263 │   │   │   │   │   save_dir=save_dir,                                 │
│                                                                              │
│ D:\Program\DRM\unshackle-dev\unshackle\core\manifests\hls.py:264 in          │
│ download_track                                                               │
│                                                                              │
│    261 │   │   │   │   │   sys.exit(1)                                       │
│    262 │   │   │   │   playlist_text = response.text                         │
│    263 │   │   │   else:                                                     │
│ ❱  264 │   │   │   │   raise TypeError(                                      │
│    265 │   │   │   │   │   f"Expected response to be a requests.Response or  │
│    266 │   │   │   │   )                                                     │
│    267                                                                       │
╰──────────────────────────────────────────────────────────────────────────────╯
TypeError: Expected response to be a requests.Response or curl_cffi.Response,
not <class 'curl_cffi.requests.models.Response'>

     ❌ Download Failed...

