### PR TITLE
Fix an N_m3u8DL-RE bug in Windows os

### DIFF
--- a/unshackle/core/downloaders/n_m3u8dl_re.py
+++ b/unshackle/core/downloaders/n_m3u8dl_re.py
@@ -305,7 +305,7 @@ def download(
 
     log_file_path: Path | None = None
     if debug_logger:
-        log_file_path = output_dir / f".n_m3u8dl_re_{filename}.log"
+        log_file_path = config.directories.temp / f"n_m3u8dl_re_{filename}.log"
         arguments.extend([
             "--log-file-path", str(log_file_path),
             "--log-level", "DEBUG",


### PR DESCRIPTION
N_m3u8DL-RE is unable to find the decryption binary program path with the "--decryption-binary-path" command in Windows operating systems. Setting the binary program path with the environment variable settings in the subprocess will work without problems in Windows operating systems.

It's probably expected to be an N_m3u8DL-RE program bug, but it's much better to fix it here because N_m3u8DL-RE doesn't update often.

    15:26:05.037 INFO : N_m3u8DL-RE (Beta version) 20251029
    Unhandled exception: System.IO.FileNotFoundException: D:\Program\DRM\unshackle-dev\unshackle\binaries\shaka-packager\shaka-packager.exe
       at N_m3u8DL_RE.Program.<DoWorkAsync>d__3.MoveNext() + 0x1bfd
    --- End of stack trace from previous location ---
       at System.CommandLine.Command.<>c__DisplayClass33_0.<<SetAction>b__0>d.MoveNext() + 0x45
    --- End of stack trace from previous location ---
       at System.CommandLine.Invocation.InvocationPipeline.<InvokeAsync>d__0.MoveNext() + 0x198