### PR TITLE
feat(core): save service title id/url and name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ device_client_id_blob
 device_private_key
 device_vmp_blob
 unshackle/cache/
+unshackle/saved_titles/
 unshackle/cookies/
 unshackle/certs/
 unshackle/WVDs/

--- a/docs/OUTPUT_CONFIG.md
+++ b/docs/OUTPUT_CONFIG.md
@@ -101,6 +101,7 @@ The following directories are available and may be overridden,
 - `downloads` - Downloads.
 - `temp` - Temporary files or conversions during download.
 - `cache` - Expiring data like Authorization tokens, or other misc data.
+- `saved_titles` - Saved title IDs and names.
 - `cookies` - Expiring Cookie data.
 - `logs` - Logs.
 - `wvds` - Widevine Devices.

--- a/docs/SERVICE_CONFIG.md
+++ b/docs/SERVICE_CONFIG.md
@@ -114,3 +114,9 @@ Maximum retention time in seconds for serving slightly stale cached title metada
 Default: `86400` (24 hours). Effective retention is `min(title_cache_time + grace, title_cache_max_retention)`.
 
 ---
+
+## saved_titles_enabled (bool)
+
+Enable/disable saving title IDs and names. Default: `true`.
+
+---

--- a/unshackle/commands/dl.py
+++ b/unshackle/commands/dl.py
@@ -968,7 +968,7 @@ class dl:
 
         with console.status("Fetching Title Metadata...", spinner="dots"):
             try:
-                titles = service.get_titles_cached()
+                titles = service.get_observed_titles_cached()
                 if not titles:
                     self.log.error("No titles returned, nothing to download...")
                     if self.debug_logger:
@@ -1139,7 +1139,7 @@ class dl:
 
             with console.status("Getting tracks...", spinner="dots"):
                 try:
-                    title.tracks.add(service.get_tracks(title), warn_only=True)
+                    service.get_observed_tracks(title)
                     title.tracks.chapters = service.get_chapters(title)
                 except Exception as e:
                     if self.debug_logger:

--- a/unshackle/core/api/handlers.py
+++ b/unshackle/core/api/handlers.py
@@ -463,12 +463,13 @@ async def list_titles_handler(data: Dict[str, Any], request: Optional[web.Reques
                 filtered_kwargs[key] = value
 
         service_instance = service_module(service_ctx, **filtered_kwargs)
+        service_instance.title_input = str(title_id)
 
         cookies = dl.get_cookie_jar(normalized_service, profile)
         credential = dl.get_credentials(normalized_service, profile)
         service_instance.authenticate(cookies, credential)
 
-        titles = service_instance.get_titles()
+        titles = service_instance.get_observed_titles()
 
         if hasattr(titles, "__iter__") and not isinstance(titles, str):
             title_list = [serialize_title(t) for t in titles]
@@ -611,12 +612,13 @@ async def list_tracks_handler(data: Dict[str, Any], request: Optional[web.Reques
                 filtered_kwargs[key] = value
 
         service_instance = service_module(service_ctx, **filtered_kwargs)
+        service_instance.title_input = str(title_id)
 
         cookies = dl.get_cookie_jar(normalized_service, profile)
         credential = dl.get_credentials(normalized_service, profile)
         service_instance.authenticate(cookies, credential)
 
-        titles = service_instance.get_titles()
+        titles = service_instance.get_observed_titles()
 
         wanted_param = data.get("wanted")
         season = data.get("season")
@@ -680,7 +682,7 @@ async def list_tracks_handler(data: Dict[str, Any], request: Optional[web.Reques
 
                     for title in sorted_titles:
                         try:
-                            tracks = service_instance.get_tracks(title)
+                            tracks = service_instance.get_observed_tracks(title)
                             video_tracks = sorted(tracks.videos, key=lambda t: t.bitrate or 0, reverse=True)
                             audio_tracks = sorted(tracks.audio, key=lambda t: t.bitrate or 0, reverse=True)
 
@@ -726,7 +728,7 @@ async def list_tracks_handler(data: Dict[str, Any], request: Optional[web.Reques
         else:
             first_title = titles
 
-        tracks = service_instance.get_tracks(first_title)
+        tracks = service_instance.get_observed_tracks(first_title)
 
         video_tracks = sorted(tracks.videos, key=lambda t: t.bitrate or 0, reverse=True)
         audio_tracks = sorted(tracks.audio, key=lambda t: t.bitrate or 0, reverse=True)

--- a/unshackle/core/config.py
+++ b/unshackle/core/config.py
@@ -22,6 +22,7 @@ class Config:
         downloads = core_dir.parent.parent / "downloads"
         temp = core_dir.parent.parent / "temp"
         cache = data / "cache"
+        saved_titles = data / "saved_titles"
         cookies = data / "cookies"
         logs = data / "logs"
         wvds = data / "WVDs"
@@ -101,6 +102,7 @@ class Config:
         self.title_cache_time: int = kwargs.get("title_cache_time", 1800)  # 30 minutes default
         self.title_cache_max_retention: int = kwargs.get("title_cache_max_retention", 86400)  # 24 hours default
         self.title_cache_enabled: bool = kwargs.get("title_cache_enabled", True)
+        self.saved_titles_enabled: bool = kwargs.get("saved_titles_enabled", True)
 
         self.debug: bool = kwargs.get("debug", False)
         self.debug_keys: bool = kwargs.get("debug_keys", False)

--- a/unshackle/core/saved_titles.py
+++ b/unshackle/core/saved_titles.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from filelock import FileLock
+
+if TYPE_CHECKING:
+    from unshackle.core.titles import Title_T
+
+
+log = logging.getLogger("SavedTitlesStore")
+
+
+@dataclass
+class SavedTitleRecord:
+    title_id: str
+    display_name: str
+
+    @classmethod
+    def from_line(cls, line: str) -> SavedTitleRecord:
+        title_id, separator, display_name = line.rstrip().partition(" | ")
+        if not separator:
+            raise ValueError(f"Invalid saved title line: {line!r}")
+        return cls(title_id.strip(), display_name.strip())
+
+    def merge(self, other: SavedTitleRecord) -> None:
+        if other.display_name:
+            self.display_name = other.display_name
+
+    def to_line(self) -> str:
+        return f"{self.title_id} | {self.display_name}"
+
+
+class SavedTitlesStore:
+    def __init__(self, directory: Path, enabled: bool = True):
+        self.directory = Path(directory)
+        self.enabled = enabled
+
+    def observe(self, service_name: str, title: Title_T, title_id: Any = None) -> None:
+        if not self.enabled:
+            return
+
+        record_id = str(title_id if title_id is not None else title.id).strip()
+        if not record_id:
+            return
+
+        record = SavedTitleRecord(record_id, get_display_name(title))
+
+        path = self.directory / f"{service_name}.txt"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path = path.with_suffix(f"{path.suffix}.lock")
+        with FileLock(str(lock_path)):
+            records = load_records(path)
+            current = records.get(record.title_id)
+            if current:
+                current.merge(record)
+            else:
+                records[record.title_id] = record
+
+            write_records(path, records)
+
+
+def get_display_name(title: Any) -> str:
+    if hasattr(title, "title") and hasattr(title, "season"):
+        name = str(title.title).strip()
+        if getattr(title, "year", None):
+            name += f" ({title.year})"
+        return name
+
+    if hasattr(title, "artist") and hasattr(title, "album"):
+        name = f"{title.artist} - {title.album}".strip(" -")
+        if getattr(title, "year", None):
+            name += f" ({title.year})"
+        return name
+
+    if hasattr(title, "name"):
+        name = str(title.name).strip()
+        if getattr(title, "year", None):
+            name += f" ({title.year})"
+        return name
+
+    return str(title).strip()
+
+
+def load_records(path: Path) -> dict[str, SavedTitleRecord]:
+    records: dict[str, SavedTitleRecord] = {}
+    if not path.exists():
+        return records
+
+    for line in path.read_text(encoding="utf8").splitlines():
+        if not line.strip():
+            continue
+
+        try:
+            record = SavedTitleRecord.from_line(line)
+        except ValueError as exc:
+            log.warning("Skipping invalid saved title line in %s: %s", path, exc)
+            continue
+
+        current = records.get(record.title_id)
+        if current:
+            current.merge(record)
+        else:
+            records[record.title_id] = record
+
+    return records
+
+
+def write_records(path: Path, records: dict[str, SavedTitleRecord]) -> None:
+    content = "\n".join(item.to_line() for item in records.values()) + "\n"
+    temp_path = path.with_suffix(f"{path.suffix}.tmp")
+    temp_path.write_text(content, encoding="utf8")
+    temp_path.replace(path)
+
+
+@lru_cache(maxsize=1)
+def get_saved_titles_store() -> SavedTitlesStore:
+    from unshackle.core.config import config
+
+    return SavedTitlesStore(config.directories.saved_titles, config.saved_titles_enabled)
+
+
+__all__ = ("SavedTitleRecord", "SavedTitlesStore", "get_saved_titles_store")

--- a/unshackle/core/service.py
+++ b/unshackle/core/service.py
@@ -20,6 +20,7 @@ from unshackle.core.console import console
 from unshackle.core.constants import AnyTrack
 from unshackle.core.credential import Credential
 from unshackle.core.drm import DRM_T
+from unshackle.core.saved_titles import get_saved_titles_store
 from unshackle.core.search_result import SearchResult
 from unshackle.core.title_cacher import TitleCacher, get_account_hash, get_region_from_proxy
 from unshackle.core.titles import Title_T, Titles_T
@@ -88,6 +89,11 @@ class Service(metaclass=ABCMeta):
         self.ctx = ctx
         self.credential = None  # Will be set in authenticate()
         self.current_region = None  # Will be set based on proxy/geolocation
+        self.title_input = None
+        if getattr(ctx, "params", None):
+            title_input = ctx.params.get("title") or ctx.params.get("title_id")
+            if title_input not in (None, ""):
+                self.title_input = str(title_input)
 
         if not ctx.parent or not ctx.parent.params.get("no_proxy"):
             if ctx.parent:
@@ -360,6 +366,47 @@ class Service(metaclass=ABCMeta):
             no_cache=no_cache,
             reset_cache=reset_cache,
         )
+
+    def observe_titles(self, titles: Titles_T) -> Titles_T:
+        """
+        Save the requested title ID and title name after titles are fetched.
+
+        If saving fails, continue without interrupting normal title handling.
+        """
+        try:
+            observed_title = None
+            if hasattr(titles, "__getitem__") and hasattr(titles, "__len__"):
+                if len(titles) > 0:
+                    observed_title = titles[0]
+            else:
+                observed_title = titles
+
+            if observed_title is None:
+                return titles
+
+            title_id = self.title_input or getattr(self, "title", None) or getattr(self, "title_id", None)
+            get_saved_titles_store().observe(self.__class__.__name__, observed_title, title_id=title_id)
+        except Exception as exc:
+            self.log.debug("Failed to save title ID and name for %r: %s", titles, exc)
+
+        return titles
+
+    def get_observed_titles(self) -> Titles_T:
+        """Fetch titles and save the requested title ID and title name."""
+        return self.observe_titles(self.get_titles())
+
+    def get_observed_titles_cached(self, title_id: str = None) -> Titles_T:
+        """Fetch cached titles and save the requested title ID and title name."""
+        return self.observe_titles(self.get_titles_cached(title_id=title_id))
+
+    def get_observed_tracks(self, title: Title_T) -> Tracks:
+        """
+        Fetch tracks and add them to ``title.tracks``.
+        """
+        tracks = self.get_tracks(title)
+        title.tracks.add(tracks, warn_only=True)
+
+        return tracks
 
     @abstractmethod
     def get_tracks(self, title: Title_T) -> Tracks:

--- a/unshackle/unshackle-example.yaml
+++ b/unshackle/unshackle-example.yaml
@@ -39,6 +39,9 @@ title_cache_enabled: true # Enable/disable title caching globally (default: true
 title_cache_time: 1800 # Cache duration in seconds (default: 1800 = 30 minutes)
 title_cache_max_retention: 86400 # Maximum cache retention for fallback when API fails (default: 86400 = 24 hours)
 
+# Save requested title IDs and names
+saved_titles_enabled: true # Enable/disable saving title IDs and names (default: true)
+
 # Debug logging configuration
 # Comprehensive JSON-based debug logging for troubleshooting and service development
 debug:
@@ -91,6 +94,7 @@ credentials:
 # Override default directories used across unshackle
 directories:
   cache: Cache
+  saved_titles: saved_titles
   cookies: Cookies
   dcsl: DCSL # Device Certificate Status List
   downloads: Downloads


### PR DESCRIPTION
Save title id/url locally so they can be reused later without querying the site again.

Titles are written to `saved_titles/{Service}.txt`.

Example entries:
```
81751482 | Made in Nowhere (2026)
80015281 | Weird Things (2016)
81904993 | The Art of Mia (2026)
70135581 | Outsider (2014)
https://example.com//vod/2924489 | Stranger (2025)
