### PR TITLE
Add optional session parameter to Track class

### DIFF
--- a/unshackle/commands/dl.py
+++ b/unshackle/commands/dl.py
@@ -1948,7 +1948,7 @@ class dl:
                             (
                                 pool.submit(
                                     track.download,
-                                    session=service.session,
+                                    session= track.session or service.session,
                                     prepare_drm=partial(
                                         partial(self.prepare_drm, table=download_table),
                                         track=track,

--- a/unshackle/core/tracks/track.py
+++ b/unshackle/core/tracks/track.py
@@ -45,6 +45,7 @@ class Track:
         name: Optional[str] = None,
         drm: Optional[Iterable[DRM_T]] = None,
         edition: Optional[str] = None,
+        session: Optional[Session] = None,
         downloader: Optional[Callable] = None,
         downloader_args: Optional[dict] = None,
         from_file: Optional[Path] = None,
@@ -104,6 +105,7 @@ class Track:
         self.name = name
         self.drm = drm
         self.edition: list[str] = [edition] if isinstance(edition, str) else (edition or [])
+        self.session = session or None
         self.downloader = downloader
         self.downloader_args = downloader_args
         self.from_file = from_file


### PR DESCRIPTION
Some service require different headers/cookies/session on each track. So I add session parameter to use when track.download called in result.