### PR TITLE
episode.py: season/seasons pluralization

### DIFF
--- a/unshackle/core/titles/episode.py
+++ b/unshackle/core/titles/episode.py
@@ -149,7 +149,7 @@ class Series(SortedKeyList, ABC):
         sum(seasons.values())
         season_breakdown = ", ".join(f"S{season}({count})" for season, count in sorted(seasons.items()))
         tree = Tree(
-            f"{num_seasons} seasons, {season_breakdown}",
+            f"{num_seasons} season{'s'[:num_seasons^1]}, {season_breakdown}",
             guide_style="bright_black",
         )
         if verbose:


### PR DESCRIPTION
If num_seasons = 0, output "0 seasons" (not sure if this would ever occur). If num_seasons = 1, output "1 season". If num_seasons >=2 output "X seasons".