### PR TITLE
feat: add automatic Firefox cookie and localstorage extraction

### DIFF
--- a/unshackle/commands/dl.py
+++ b/unshackle/commands/dl.py
@@ -2921,8 +2921,20 @@ class dl:
             return default_cookie_file
 
     @staticmethod
-    def get_cookie_jar(service: str, profile: Optional[str]) -> Optional[MozillaCookieJar]:
+    def get_cookie_jar(service: str, profile: Optional[str]) -> Optional[CookieJar]:
         """Get Service Cookies for Profile."""
+        # Check if automatic Firefox cookie extraction is configured for this service
+        ff_settings = getattr(config, "firefox_cookies", {}).get(service)
+        if ff_settings:
+            try:
+                from unshackle.core.utils.firefox_cookie_extractor import get_firefox_cookies
+                extracted_jar = get_firefox_cookies(ff_settings)
+                if extracted_jar:
+                    return extracted_jar
+            except Exception:
+                # Fallback to file-based if Firefox extraction fails
+                pass
+
         cookie_file = dl.get_cookie_path(service, profile)
         if cookie_file:
             cookie_jar = MozillaCookieJar(cookie_file)
@@ -2939,6 +2951,8 @@ class dl:
             cookie_file.write_text(cookie_data, "utf8")
             cookie_jar.load(ignore_discard=True, ignore_expires=True)
             return cookie_jar
+            
+        return None
 
     @staticmethod
     def save_cookies(path: Path, cookies: CookieJar):

--- a/unshackle/core/config.py
+++ b/unshackle/core/config.py
@@ -48,6 +48,7 @@ class Config:
         self.curl_impersonate: dict = kwargs.get("curl_impersonate") or {}
         self.remote_cdm: list[dict] = kwargs.get("remote_cdm") or []
         self.credentials: dict = kwargs.get("credentials") or {}
+        self.firefox_cookies: dict = kwargs.get("firefox_cookies") or {}
         self.subtitle: dict = kwargs.get("subtitle") or {}
 
         self.directories = self._Directories()

--- a/unshackle/core/utils/firefox_cookie_extractor.py
+++ b/unshackle/core/utils/firefox_cookie_extractor.py
@@ -1,0 +1,156 @@
+"""
+Firefox Cookie and LocalStorage Extractor Utility for unshackle.
+Provides a read-only mechanism to extract authentication tokens from Firefox.
+"""
+
+import sqlite3
+import platform
+import os
+import time
+import shutil
+from pathlib import Path
+from tempfile import gettempdir
+from http.cookiejar import CookieJar, Cookie
+from typing import Dict, Optional, List
+
+
+def get_firefox_root() -> Path:
+    """Locates the operating system specific root directory for Firefox profiles."""
+    system = platform.system()
+    home = Path.home()
+    
+    if system == 'Windows':
+        return Path(os.getenv('APPDATA', '')) / 'Mozilla' / 'Firefox'
+    elif system == 'Darwin':
+        return home / 'Library' / 'Application Support' / 'Firefox'
+    elif system == 'Linux':
+        paths = [
+            home / '.mozilla' / 'firefox',
+            home / 'snap' / 'firefox' / 'common' / '.mozilla' / 'firefox',
+            home / '.var' / 'app' / 'org.mozilla.firefox' / '.mozilla' / 'firefox'
+        ]
+        for p in paths:
+            if p.exists():
+                return p
+        return paths[0]
+    else:
+        raise RuntimeError(f"Unsupported operating system discovered: {system}")
+
+
+def get_latest_profile_path(firefox_root: Path) -> Path:
+    """Finds the most recently modified valid Firefox profile subdirectory."""
+    search_dirs = [firefox_root / 'Profiles', firefox_root]
+    valid_profiles = []
+    
+    for base_dir in search_dirs:
+        if base_dir.exists():
+            for p in base_dir.iterdir():
+                if p.is_dir() and (p / 'cookies.sqlite').exists():
+                    valid_profiles.append(p)
+    
+    if not valid_profiles:
+        raise FileNotFoundError(f"No active Firefox profiles detected at: {firefox_root}")
+
+    return max(valid_profiles, key=lambda p: (p / 'cookies.sqlite').stat().st_mtime)
+
+
+def get_local_storage_data(profile_path: Path, hosts: List[str]) -> Dict[str, str]:
+    """
+    Safely extracts key-value tokens from Firefox LocalStorage (webappsstore.sqlite).
+    """
+    ls_db = profile_path / 'webappsstore.sqlite'
+    if not ls_db.exists():
+        return {}
+        
+    temp_db = Path(gettempdir()) / f"unshackle_ls_{int(time.time())}.sqlite"
+    extracted_storage = {}
+    
+    try:
+        shutil.copy2(ls_db, temp_db)
+        conn = sqlite3.connect(temp_db)
+        cursor = conn.cursor()
+        
+        for host in hosts:
+            reversed_host = host[::-1]
+            query = "SELECT key, value FROM webappsstore2 WHERE originKey LIKE ? OR originKey LIKE ?"
+            cursor.execute(query, (f'%{host}%', f'%{reversed_host}%'))
+            
+            for key, value in cursor.fetchall():
+                extracted_storage[key] = value
+                
+        conn.close()
+    except Exception:
+        pass
+    finally:
+        if temp_db.exists():
+            os.remove(temp_db)
+            
+    return extracted_storage
+
+
+def get_firefox_cookies(service_settings: dict) -> Optional[CookieJar]:
+    """
+    Extracts cookies and localstorage from Firefox based on provided host patterns.
+    Returns a standard CookieJar.
+    """
+    priority_hosts = service_settings.get('hosts', [])
+    include_filter = service_settings.get('include', [])
+
+    try:
+        firefox_root = get_firefox_root()
+        profile_path = get_latest_profile_path(firefox_root)
+    except Exception:
+        return None
+    
+    temp_db = Path(gettempdir()) / f"unshackle_cookies_{int(time.time())}.sqlite"
+    cookie_jar = CookieJar()
+    
+    try:
+        shutil.copy2(profile_path / 'cookies.sqlite', temp_db)
+        conn = sqlite3.connect(temp_db)
+        cursor = conn.cursor()
+
+        host_patterns = [f"%{h}%" for h in priority_hosts]
+        if not host_patterns:
+            return None
+
+        query = "SELECT host, name, value, path, expiry FROM moz_cookies WHERE " + " OR ".join(["host LIKE ?"] * len(host_patterns))
+        cursor.execute(query, host_patterns)
+        rows = cursor.fetchall()
+
+        for host, name, value, path, expiry in rows:
+            if include_filter and name not in include_filter:
+                continue
+                
+            c = Cookie(
+                version=0, name=name, value=value,
+                port=None, port_specified=False,
+                domain=host, domain_specified=True, domain_initial_dot=host.startswith('.'),
+                path=path, path_specified=True,
+                secure=False, expires=expiry, discard=False, comment=None, comment_url=None, rest={'HttpOnly': None}, rfc2109=False
+            )
+            cookie_jar.set_cookie(c)
+            
+        conn.close()
+    except Exception:
+        return None
+    finally:
+        if temp_db.exists():
+            os.remove(temp_db)
+
+    # Supplement with LocalStorage data
+    storage_data = get_local_storage_data(profile_path, priority_hosts)
+    for key, val in storage_data.items():
+        if include_filter and key not in include_filter:
+            continue
+            
+        c = Cookie(
+            version=0, name=key, value=val,
+            port=None, port_specified=False,
+            domain=".localstorage", domain_specified=True, domain_initial_dot=False,
+            path='/', path_specified=True,
+            secure=False, expires=None, discard=True, comment=None, comment_url=None, rest={}, rfc2109=False
+        )
+        cookie_jar.set_cookie(c)
+
+    return cookie_jar if len(list(cookie_jar)) > 0 else None

--- a/unshackle/core/utils/firefox_cookie_extractor.py
+++ b/unshackle/core/utils/firefox_cookie_extractor.py
@@ -1,15 +1,14 @@
 """
 Firefox Cookie and LocalStorage Extractor Utility for unshackle.
-Provides a read-only mechanism to extract authentication tokens from Firefox.
+Provides a secure, read-only mechanism to extract authentication tokens from Firefox.
 """
 
 import sqlite3
 import platform
 import os
-import time
 import shutil
+import tempfile
 from pathlib import Path
-from tempfile import gettempdir
 from http.cookiejar import CookieJar, Cookie
 from typing import Dict, Optional, List
 
@@ -18,7 +17,6 @@ def get_firefox_root() -> Path:
     """Locates the operating system specific root directory for Firefox profiles."""
     system = platform.system()
     home = Path.home()
-    
     if system == 'Windows':
         return Path(os.getenv('APPDATA', '')) / 'Mozilla' / 'Firefox'
     elif system == 'Darwin':
@@ -33,47 +31,46 @@ def get_firefox_root() -> Path:
             if p.exists():
                 return p
         return paths[0]
-    else:
-        raise RuntimeError(f"Unsupported operating system discovered: {system}")
+    raise RuntimeError(f"Unsupported operating system: {system}")
 
 
-def get_latest_profile_path(firefox_root: Path) -> Path:
+def get_latest_profile_path(ff_root: Path) -> Path:
     """Finds the most recently modified valid Firefox profile subdirectory."""
-    search_dirs = [firefox_root / 'Profiles', firefox_root]
+    search_dirs = [ff_root / 'Profiles', ff_root]
     valid_profiles = []
-    
-    for base_dir in search_dirs:
-        if base_dir.exists():
-            for p in base_dir.iterdir():
-                if p.is_dir() and (p / 'cookies.sqlite').exists():
-                    valid_profiles.append(p)
+    for base in search_dirs:
+        if base.exists():
+            valid_profiles.extend([p for p in base.iterdir() if p.is_dir() and (p / 'cookies.sqlite').exists()])
     
     if not valid_profiles:
-        raise FileNotFoundError(f"No active Firefox profiles detected at: {firefox_root}")
+        raise FileNotFoundError("No active Firefox profiles detected.")
 
     return max(valid_profiles, key=lambda p: (p / 'cookies.sqlite').stat().st_mtime)
 
 
-def get_local_storage_data(profile_path: Path, hosts: List[str]) -> Dict[str, str]:
+def get_local_storage_data(profile_path: Path, hosts: List[str], tmp_dir_path: Path) -> Dict[str, str]:
     """
-    Safely extracts key-value tokens from Firefox LocalStorage (webappsstore.sqlite).
+    Extracts LocalStorage tokens from webappsstore.sqlite with strict origin matching.
+    Operates within a secure temporary directory.
     """
     ls_db = profile_path / 'webappsstore.sqlite'
     if not ls_db.exists():
         return {}
         
-    temp_db = Path(gettempdir()) / f"unshackle_ls_{int(time.time())}.sqlite"
+    temp_ls = tmp_dir_path / "webappsstore.sqlite"
     extracted_storage = {}
     
     try:
-        shutil.copy2(ls_db, temp_db)
-        conn = sqlite3.connect(temp_db)
+        shutil.copy2(ls_db, temp_ls)
+        conn = sqlite3.connect(temp_ls)
         cursor = conn.cursor()
         
         for host in hosts:
+            # Firefox stores LocalStorage as reversed host (e.g., moc.viki.:https:443)
+            # Use strict prefix matching to prevent over-broad harvesting
             reversed_host = host[::-1]
-            query = "SELECT key, value FROM webappsstore2 WHERE originKey LIKE ? OR originKey LIKE ?"
-            cursor.execute(query, (f'%{host}%', f'%{reversed_host}%'))
+            query = "SELECT key, value FROM webappsstore2 WHERE originKey LIKE ?"
+            cursor.execute(query, (f"{reversed_host}.%",))
             
             for key, value in cursor.fetchall():
                 extracted_storage[key] = value
@@ -81,76 +78,84 @@ def get_local_storage_data(profile_path: Path, hosts: List[str]) -> Dict[str, st
         conn.close()
     except Exception:
         pass
-    finally:
-        if temp_db.exists():
-            os.remove(temp_db)
             
     return extracted_storage
 
 
 def get_firefox_cookies(service_settings: dict) -> Optional[CookieJar]:
     """
-    Extracts cookies and localstorage from Firefox based on provided host patterns.
-    Returns a standard CookieJar.
+    Extracts cookies and optionally localStorage from Firefox based on provided host patterns.
+    Implements security hardening and data consistency (WAL support) as per PR review.
     """
-    priority_hosts = service_settings.get('hosts', [])
-    include_filter = service_settings.get('include', [])
+    raw_hosts = service_settings.get('hosts', [])
+    # Filter empty or dangerously short hosts to prevent full store dumps (Finding #3)
+    priority_hosts = [h.strip().lower() for h in raw_hosts if h and len(h.strip()) >= 3]
+    use_local_storage = service_settings.get('local_storage', False)
+
+    if not priority_hosts:
+        return None
 
     try:
-        firefox_root = get_firefox_root()
-        profile_path = get_latest_profile_path(firefox_root)
+        profile_path = get_latest_profile_path(get_firefox_root())
     except Exception:
         return None
     
-    temp_db = Path(gettempdir()) / f"unshackle_cookies_{int(time.time())}.sqlite"
     cookie_jar = CookieJar()
-    
-    try:
-        shutil.copy2(profile_path / 'cookies.sqlite', temp_db)
-        conn = sqlite3.connect(temp_db)
-        cursor = conn.cursor()
 
-        host_patterns = [f"%{h}%" for h in priority_hosts]
-        if not host_patterns:
+    # Use a secure temporary directory with restricted permissions (Finding #5)
+    with tempfile.TemporaryDirectory(prefix="unshackle_ff_") as tmp_dir:
+        tmp_dir_path = Path(tmp_dir)
+        os.chmod(tmp_dir, 0o700) 
+        
+        temp_db = tmp_dir_path / "cookies.sqlite"
+        temp_wal = tmp_dir_path / "cookies.sqlite-wal"
+
+        try:
+            # Copy main DB and its WAL log to ensure fresh data capture (Finding #5)
+            shutil.copy2(profile_path / 'cookies.sqlite', temp_db)
+            wal_path = profile_path / 'cookies.sqlite-wal'
+            if wal_path.exists():
+                shutil.copy2(wal_path, temp_wal)
+
+            conn = sqlite3.connect(temp_db)
+            cursor = conn.cursor()
+
+            for host in priority_hosts:
+                # Precise matching: exact host or dot-prefixed domain suffix (Finding #2)
+                query = """
+                    SELECT host, name, value, path, expiry, isSecure, isHttpOnly 
+                    FROM moz_cookies 
+                    WHERE host = ? OR host LIKE ?
+                """
+                cursor.execute(query, (host, f"%.{host}"))
+                rows = cursor.fetchall()
+
+                for h, n, v, p, e, secure, httponly in rows:
+                    # Final validation to ensure proper domain suffix
+                    if h == host or h.endswith(f".{host}"):
+                        c = Cookie(
+                            version=0, name=n, value=v, port=None, port_specified=False,
+                            domain=h, domain_specified=True, domain_initial_dot=h.startswith('.'),
+                            path=p, path_specified=True, secure=bool(secure), expires=e,
+                            discard=False, comment=None, comment_url=None, 
+                            rest={'HttpOnly': str(bool(httponly))}, rfc2109=False
+                        )
+                        cookie_jar.set_cookie(c)
+            conn.close()
+
+            # Optional LocalStorage harvesting (Finding #4)
+            if use_local_storage:
+                storage_data = get_local_storage_data(profile_path, priority_hosts, tmp_dir_path)
+                for key, val in storage_data.items():
+                    c = Cookie(
+                        version=0, name=key, value=val, port=None, port_specified=False,
+                        domain=".localstorage", domain_specified=True, domain_initial_dot=False,
+                        path='/', path_specified=True, secure=False, expires=None,
+                        discard=True, comment=None, comment_url=None, rest={}, rfc2109=False
+                    )
+                    cookie_jar.set_cookie(c)
+
+        except Exception:
             return None
-
-        query = "SELECT host, name, value, path, expiry FROM moz_cookies WHERE " + " OR ".join(["host LIKE ?"] * len(host_patterns))
-        cursor.execute(query, host_patterns)
-        rows = cursor.fetchall()
-
-        for host, name, value, path, expiry in rows:
-            if include_filter and name not in include_filter:
-                continue
-                
-            c = Cookie(
-                version=0, name=name, value=value,
-                port=None, port_specified=False,
-                domain=host, domain_specified=True, domain_initial_dot=host.startswith('.'),
-                path=path, path_specified=True,
-                secure=False, expires=expiry, discard=False, comment=None, comment_url=None, rest={'HttpOnly': None}, rfc2109=False
-            )
-            cookie_jar.set_cookie(c)
-            
-        conn.close()
-    except Exception:
-        return None
-    finally:
-        if temp_db.exists():
-            os.remove(temp_db)
-
-    # Supplement with LocalStorage data
-    storage_data = get_local_storage_data(profile_path, priority_hosts)
-    for key, val in storage_data.items():
-        if include_filter and key not in include_filter:
-            continue
-            
-        c = Cookie(
-            version=0, name=key, value=val,
-            port=None, port_specified=False,
-            domain=".localstorage", domain_specified=True, domain_initial_dot=False,
-            path='/', path_specified=True,
-            secure=False, expires=None, discard=True, comment=None, comment_url=None, rest={}, rfc2109=False
-        )
-        cookie_jar.set_cookie(c)
 
     return cookie_jar if len(list(cookie_jar)) > 0 else None


### PR DESCRIPTION
Introduces a configuration-driven mechanism to extract session data from Firefox.

**Explicit Configuration:** 
The extraction logic is only triggered if a service is defined within the firefox_cookies section in unshackle.yaml.

**Read-Only Access:** 
All operations are performed on temporary copies of the databases to ensure the original browser profile remains untouched and unlocked.

**Fallback Logic:** 
The system maintains full backward compatibility, falling back to traditional file-based cookies if the Firefox configuration is absent or the extraction returns no results.

**Example in Configuration file:**

```
firefox_cookies:
  MY_SERVICE:
    hosts: ["example.com", "api.example.com"]
  MY_SERVICE_2:
    hosts: ["api.example.com"]
```