### PR TITLE
fix(hls): decrypt AES-128 (ClearKey) media-playlist keys + per-segment sequence IV

### DIFF
--- a/unshackle/core/manifests/hls.py
+++ b/unshackle/core/manifests/hls.py
@@ -570,6 +570,14 @@ class HLS:
                         DOWNLOAD_CANCELLED.set()  # skip pending track downloads
                         progress(downloaded="[red]FAILED")
                         raise
+                elif isinstance(media_drm, ClearKey):
+                    # AES-128 (ClearKey) needs no license server — the key is already fetched.
+                    # Without this branch session_drm stayed None and segments were never
+                    # decrypted (they were merged still-encrypted, producing a broken file).
+                    track.drm = [media_drm]
+                    session_drm = media_drm
+                    initial_drm_key = media_playlist_key
+                    initial_drm_licensed = True
 
         # Fall back to session DRM if media playlist has no matching keys
         if not initial_drm_licensed and session_drm and isinstance(session_drm, (Widevine, PlayReady)):
@@ -682,6 +690,9 @@ class HLS:
         name_len = len(str(total_segments))
         discon_i = 0
         range_offset = 0
+        # First segment's Media Sequence Number — used as the AES-128 IV when EXT-X-KEY has
+        # no explicit IV (RFC 8216 §5.2), where each segment's IV is its sequence number.
+        media_sequence_start = getattr(master, "media_sequence", None) or 0
         map_data: Optional[tuple[m3u8.model.InitializationSection, bytes]] = None
         if session_drm:
             encryption_data: Optional[tuple[Optional[m3u8.Key], DRM_T]] = (initial_drm_key, session_drm)
@@ -760,7 +771,14 @@ class HLS:
                 else:
                     # with other drm we must decrypt separately and then merge them
                     # for aes this is because each segment likely has 16-byte padding
+                    key_obj = encryption_data[0]
+                    # AES-128 with no explicit IV: each segment's IV is its media sequence
+                    # number (RFC 8216 §5.2). Without this the engine used a zero IV and the
+                    # output decrypted to garbage.
+                    seq_iv = isinstance(drm, ClearKey) and not (key_obj and key_obj.iv)
                     for file in files:
+                        if seq_iv and file.stem.isdigit():
+                            drm.iv = (media_sequence_start + int(file.stem)).to_bytes(16, "big")
                         drm.decrypt(file)
                     merge(to=merged_path, via=files, delete=True, include_map_data=True)
 

--- a/unshackle/core/manifests/hls.py
+++ b/unshackle/core/manifests/hls.py
@@ -571,7 +571,7 @@ class HLS:
                         progress(downloaded="[red]FAILED")
                         raise
                 elif isinstance(media_drm, ClearKey):
-                    # AES-128 (ClearKey) needs no license server — the key is already fetched.
+                    # AES-128 (ClearKey) needs no license server - the key is already fetched.
                     # Without this branch session_drm stayed None and segments were never
                     # decrypted (they were merged still-encrypted, producing a broken file).
                     track.drm = [media_drm]
@@ -690,7 +690,7 @@ class HLS:
         name_len = len(str(total_segments))
         discon_i = 0
         range_offset = 0
-        # First segment's Media Sequence Number — used as the AES-128 IV when EXT-X-KEY has
+        # First segment's Media Sequence Number - used as the AES-128 IV when EXT-X-KEY has
         # no explicit IV (RFC 8216 §5.2), where each segment's IV is its sequence number.
         media_sequence_start = getattr(master, "media_sequence", None) or 0
         map_data: Optional[tuple[m3u8.model.InitializationSection, bytes]] = None


### PR DESCRIPTION
Splitting this out of #113 as suggested, since it stands on its own with no coupling to the API work.

### Problem
On an HLS stream protected with AES-128 (`ClearKey`), the download path only wired up a media-playlist key when it was Widevine/PlayReady. A `ClearKey` was built from the `EXT-X-KEY` but **never assigned to `session_drm`**, so segments were merged still-encrypted and the output was unplayable (a few-KB garbage file).

### Fix
- Handle `ClearKey` from the media playlist directly — no license server is needed, the key is already fetched. It's assigned to `session_drm` so the segment loop decrypts.
- When `EXT-X-KEY` carries no explicit `IV`, each segment uses its media sequence number as the IV (RFC 8216 §5.2). The sequence number is derived the same way the surrounding code already names segments (`media_sequence_start + int(file.stem)`); when the key has an explicit `IV` it's left untouched.

### Verification
Tested end-to-end against a real AES-128 HLS stream — a full ~84-minute episode now decrypts to a valid, playable file (was 0 MiB / garbage before).

Scoped to `unshackle/core/manifests/hls.py`, +18 lines, no behavioural change for Widevine/PlayReady/DRM-free paths.
