### PR TITLE
feat(api): expose title description, date and cover_url in serialize_title

### DIFF
--- a/unshackle/core/api/handlers.py
+++ b/unshackle/core/api/handlers.py
@@ -250,6 +250,13 @@ def validate_service(service_tag: str, request: Optional[web.Request] = None) ->
 def serialize_title(title: Title_T) -> Dict[str, Any]:
     """Convert a title object to JSON-serializable dict."""
     title_language = str(title.language) if hasattr(title, "language") and title.language else None
+    # Optional display metadata a service may provide: a synopsis (title.description) and a
+    # release/air date or poster image URL stashed in title.data. Surfaced so a client can show
+    # a richer listing without re-fetching the page.
+    description = getattr(title, "description", None) or None
+    _data = getattr(title, "data", None)
+    date = _data.get("date") if isinstance(_data, dict) else None
+    cover_url = _data.get("cover_url") if isinstance(_data, dict) else None
 
     if isinstance(title, Episode):
         episode_name = title.name if title.name else f"Episode {title.number:02d}"
@@ -262,6 +269,9 @@ def serialize_title(title: Title_T) -> Dict[str, Any]:
             "year": title.year,
             "id": str(title.id) if hasattr(title, "id") else None,
             "language": title_language,
+            "description": description,
+            "date": date,
+            "cover_url": cover_url,
         }
     elif isinstance(title, Movie):
         result = {
@@ -270,6 +280,9 @@ def serialize_title(title: Title_T) -> Dict[str, Any]:
             "year": title.year,
             "id": str(title.id) if hasattr(title, "id") else None,
             "language": title_language,
+            "description": description,
+            "date": date,
+            "cover_url": cover_url,
         }
     else:
         result = {
@@ -277,6 +290,9 @@ def serialize_title(title: Title_T) -> Dict[str, Any]:
             "name": str(title.name) if hasattr(title, "name") else str(title),
             "id": str(title.id) if hasattr(title, "id") else None,
             "language": title_language,
+            "description": description,
+            "date": date,
+            "cover_url": cover_url,
         }
 
     return result


### PR DESCRIPTION
## What

Adds three optional fields to the title serialization used by the search/list endpoints:

- `description` - the title's synopsis (`title.description`)
- `date` - a release/air date a service stashes in `title.data["date"]`
- `cover_url` - a poster image URL a service stashes in `title.data["cover_url"]`

## Why

Lets a client render a richer listing (synopsis, date, thumbnail) without re-fetching and re-parsing the source page.

## Notes

Purely additive. All three default to `null` when the service does not provide them, so existing clients are unaffected; no return shapes change.