### PR TITLE
fix(api): gate per-request credentials behind serve.allow_job_credentials

### DIFF
--- a/unshackle/core/api/handlers.py
+++ b/unshackle/core/api/handlers.py
@@ -1278,15 +1278,21 @@ def _create_service_instance(
     service_module = Services.load(normalized_service)
     service_instance = instantiate_service(parent_ctx, service_module, title_id, data, SESSION_TRANSPORT_KEYS)
 
-    # Resolve credentials: client-sent > server-local
+    # Resolve credentials. A client-sent credential is gated behind serve.allow_job_credentials
+    # (default-deny): true permits any service, a list permits only those service tags. Unset/false
+    # ignores it and uses the server-local credential, so a server never forwards arbitrary client
+    # credentials to a service by default.
     cred_data = data.get("credentials")
-    if cred_data and isinstance(cred_data, dict):
-        credential = Credential(
-            username=cred_data["username"],
-            password=cred_data["password"],
-            extra=cred_data.get("extra"),
-        )
-    else:
+    credential = None
+    if isinstance(cred_data, dict) and cred_data.get("username") and cred_data.get("password"):
+        allowed = (config.serve or {}).get("allow_job_credentials")
+        if allowed is True or (isinstance(allowed, (list, tuple, set)) and normalized_service in allowed):
+            credential = Credential(
+                username=cred_data["username"],
+                password=cred_data["password"],
+                extra=cred_data.get("extra"),
+            )
+    if credential is None:
         credential = dl.get_credentials(normalized_service, profile)
 
     # Resolve cookies: client-sent > server-local


### PR DESCRIPTION
## Problem

`_create_service_instance` honoured a client-sent `credentials` object unconditionally, so any client able to submit a download could make the server authenticate to a service with arbitrary credentials. It also indexed `credentials["password"]` directly, raising a `KeyError` (500) on a partial payload.

## Fix

Gate the client-sent credential behind a new `serve.allow_job_credentials` config (default-deny), mirroring the existing `serve.cdm_overrides` pattern:

- `true` - accept a client credential for any service
- a list of service tags - accept it only for those services
- unset / false - ignore the client credential and use the server-local one

Also require both `username` and `password` before constructing the `Credential`, so a partial payload falls back cleanly instead of erroring.

## Notes

Default-deny: with no config set, behaviour is the safe server-local credential. A trusted front-end opts in explicitly. No return shapes change.