### PR TITLE
fix(console): pause active live contexts during terminal input

### DIFF
--- a/unshackle/core/console.py
+++ b/unshackle/core/console.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 from types import ModuleType
-from typing import IO, Callable, Iterable, List, Literal, Mapping, Optional, Union
+from typing import IO, Callable, Iterable, List, Literal, Mapping, Optional, TextIO, Union
 
 from rich._log_render import FormatTimeCallable, LogRender
 from rich.console import Console, ConsoleRenderable, HighlighterType, RenderableType
@@ -282,6 +282,35 @@ class ComfyConsole(Console):
             return Live(padding, console=self, transient=True)
 
         return status_renderable
+
+    def input(
+        self,
+        prompt: TextType = "",
+        *,
+        markup: bool = True,
+        emoji: bool = True,
+        password: bool = False,
+        stream: Optional[TextIO] = None,
+    ) -> str:
+        """Displays a prompt and waits for input from the user, temporarily pausing any active Live displays."""
+        # Find active Live displays to prevent overlap / disappearing prompt.
+        # We copy the list because stop() will modify console._live_stack.
+        active_lives = list(self._live_stack)
+
+        for live in active_lives:
+            live.stop()
+
+        try:
+            return super().input(
+                prompt=prompt,
+                markup=markup,
+                emoji=emoji,
+                password=password,
+                stream=stream,
+            )
+        finally:
+            for live in reversed(active_lives):
+                live.start()
 
 
 catppuccin_mocha = {


### PR DESCRIPTION
When a service calls `request_input` (e.g., during OTP verification in the `authenticate` phase), the terminal's active `Live` or `status` spinner contexts (handled by `rich`) would continuously refresh and redraw in the background. This caused the input prompt to disappear or become hidden immediately after rendering, although keystrokes were still registered.

This commit resolves the issue by overriding `Console.input` in `ComfyConsole` to:
1. Temporarily pause (`stop()`) all active `Live` displays before requesting input.
2. Read the user input safely without interference from the refresh loop.
3. Resume (`start()`) all previously active displays in the reverse order afterwards.