### PR TITLE
feat: add interactive TUI for guided option and track selection

### DIFF
--- a/unshackle/commands/dl.py
+++ b/unshackle/commands/dl.py
@@ -712,57 +712,70 @@ class dl:
         is_flag=True,
         default=False,
         help="Enable interactive mode to select service, tracks, and parameters.",
-    )    
+    )
     @click.pass_context
     def cli(ctx: click.Context, **kwargs: Any) -> Any:
         """Main entry point supporting both standard CLI subcommands and Interactive mode."""
-        
         # Delegate standard subcommands to the 'dl' engine
         if ctx.invoked_subcommand is not None:
             return dl(ctx, **kwargs)
 
-        # Handle interactive mode
         if kwargs.get("interactive"):
-            from unshackle.core.interactive import run_service_selector
-            from rich.prompt import Prompt
-            
+            # Function-local import avoids a circular import at module load.
+            from unshackle.core.interactive import run_service_extra_options, run_service_selector
+            from unshackle.core.utils.selector import tui_header, tui_prompt
+
             selected_service = run_service_selector()
             if not selected_service:
                 return
 
-            kwargs['tag'] = selected_service
+            # Registers dl.result as the group result callback (side effect); click then forwards
+            # the interactive service's return value to it. Do not remove.
+            kwargs["tag"] = selected_service
             dl(ctx, **kwargs)
-            
-            console.print(Padding(Rule(f"[rule.text]Enter URL or ID for {selected_service}"), (1, 2)))
-            content_id = Prompt.ask(f"   [bold cyan]URL/ID[/]").strip()
-            
+
+            tui_header(f"Enter URL or ID for {selected_service}")
+            content_id = tui_prompt("URL/ID").strip()
+
             if not content_id:
                 raise click.UsageError("Content ID/URL is required.")
 
-            # Load the service command and prompt for its specific options
             service_cmd = Services.load(selected_service)
-            from unshackle.core.interactive import run_service_extra_options
             service_kwargs = run_service_extra_options(service_cmd, ctx)
 
-            # Normalize interactive prompt outputs to match standard CLI types
+            params = getattr(service_cmd.cli, "params", [])
+            param_by_name = {p.name: p for p in params}
+
+            # Collapse single-value options to a scalar and unwrap enum .value; leave
+            # multiple / nargs=-1 options as lists.
             for k, v in service_kwargs.items():
-                if isinstance(v, list):
-                    v = v[0] if v else None
-                if hasattr(v, 'value'):
-                    v = v.value
+                param = param_by_name.get(k)
+                is_multi = bool(getattr(param, "multiple", False) or getattr(param, "nargs", 1) == -1)
+                if not is_multi:
+                    if isinstance(v, list):
+                        v = v[0] if v else None
+                    if hasattr(v, "value"):
+                        v = v.value
                 service_kwargs[k] = v
 
-            # Resolve the main argument name (typically the content URL/ID)
-            params = getattr(service_cmd.cli, "params", [])
-            arg_name = next((p.name for p in params if isinstance(p, click.Argument)), "title")
-            
+            # Fill the service's positional argument. Services normally declare a single `title`.
+            arguments = [p for p in params if isinstance(p, click.Argument)]
+            invoke_kwargs = dict(service_kwargs)
+            if arguments:
+                invoke_kwargs[arguments[0].name] = content_id
+                unfilled = [a.name for a in arguments[1:] if a.name not in invoke_kwargs]
+                if unfilled:
+                    raise click.UsageError(
+                        f"Service '{selected_service}' declares multiple arguments; "
+                        f"cannot infer values for: {', '.join(unfilled)}"
+                    )
+
             # Sync context params so they are accessible during dl.result()
             ctx.params.update(service_kwargs)
-            
-            result_service = ctx.invoke(service_cmd.cli, **{arg_name: content_id, **service_kwargs})
-            
+
+            result_service = ctx.invoke(service_cmd.cli, **invoke_kwargs)
+
             if result_service is None:
-                import logging
                 logging.getLogger("download").error(f"Failed to initialize service: {selected_service}")
                 return
 
@@ -1434,19 +1447,34 @@ class dl:
                     level="INFO", operation="get_titles", service=self.service, context={"titles": titles_info}
                 )
 
-        # Handle interactive parameter refinement
         if interactive:
+            # Function-local import avoids a circular import at module load.
             from unshackle.core.interactive import run_interactive_session
-            from unshackle.core.constants import DOWNLOAD_LICENCE_ONLY
-            
-            # Filter current local scope variables to pass as default session parameters
-            exclude = {'self', 'service', 'titles', 'start_time', 'ctx', 'log', 'exclude'}
-            current_params = {k: v for k, v in locals().items() if k not in exclude and not k.startswith('_')}
 
-            # Execute session selection
+            # Explicit defaults consumed by the interactive session (see run_interactive_session).
+            current_params = {
+                "quality": quality,
+                "vcodec": vcodec,
+                "acodec": acodec,
+                "range_": range_,
+                "a_lang": a_lang,
+                "s_lang": s_lang,
+                "vbitrate": vbitrate,
+                "abitrate": abitrate,
+                "no_mux": no_mux,
+                "list_": list_,
+                "export": export,
+                "list_titles": list_titles,
+                "forced_subs": forced_subs,
+                "audio_description": audio_description,
+                "skip_dl": skip_dl,
+                "no_subs": no_subs,
+                "latest_episode": latest_episode,
+                "select_titles": select_titles,
+            }
+
             selections = run_interactive_session(service, titles, self.log, current_params)
-            
-            # Apply selection results to local configuration variables
+
             quality = selections.get('quality', quality)
             vcodec = selections.get('vcodec', vcodec)
             acodec = selections.get('acodec', acodec)
@@ -1455,14 +1483,16 @@ class dl:
             s_lang = selections.get('s_lang', s_lang)
             vbitrate = selections.get('vbitrate', vbitrate)
             abitrate = selections.get('abitrate', abitrate)
-            
+
             no_mux = selections.get('no_mux', no_mux)
             list_ = selections.get('list_', list_)
             export = selections.get('export', export)
             if export:
                 config.directories.exports.mkdir(parents=True, exist_ok=True)
                 export_path = config.directories.exports / f"export_{self.service}_{int(time.time())}.json"
-                self.export_service = service            
+                self.export_service = service
+            else:
+                export_path = None
             list_titles = selections.get('list_titles', list_titles)
             forced_subs = selections.get('forced_subs', forced_subs)
             audio_description = selections.get('audio_description', audio_description)
@@ -1472,13 +1502,18 @@ class dl:
             worst = selections.get('v_mode', 'best') == 'worst'
             select_titles = selections.get('select_titles', select_titles)
 
-            # Update licence-only state based on final selection
+            # --worst requires an explicit quality, same as the CLI path.
+            if worst and not quality:
+                self.log.error("--worst requires -q/--quality to be specified")
+                sys.exit(1)
+
             if skip_dl:
                 DOWNLOAD_LICENCE_ONLY.set()
             else:
                 DOWNLOAD_LICENCE_ONLY.clear()
 
-            # Default language tracks to 'all' to bypass strict filtering
+            # Interactive selections drive language filtering. Video isn't language-picked in the
+            # TUI, so keep all of it; fall back to all audio only when nothing was selected.
             v_lang = ["all"]
             if not a_lang:
                 a_lang = ["all"]

--- a/unshackle/commands/dl.py
+++ b/unshackle/commands/dl.py
@@ -381,6 +381,7 @@ class dl:
     @click.command(
         short_help="Download, Decrypt, and Mux tracks for titles from a Service.",
         cls=Services,
+        invoke_without_command=True,
         context_settings=dict(
             **context_settings, default_map=normalize_dl_config(config.dl), token_normalize_func=Services.get_tag
         ),
@@ -705,9 +706,71 @@ class dl:
         is_eager=True,
         help="Name of the remote server from remote_services config (if multiple configured).",
     )
+    @click.option(
+        "-i",
+        "--interactive",
+        is_flag=True,
+        default=False,
+        help="Enable interactive mode to select service, tracks, and parameters.",
+    )    
     @click.pass_context
-    def cli(ctx: click.Context, **kwargs: Any) -> dl:
-        return dl(ctx, **kwargs)
+    def cli(ctx: click.Context, **kwargs: Any) -> Any:
+        """Main entry point supporting both standard CLI subcommands and Interactive mode."""
+        
+        # Delegate standard subcommands to the 'dl' engine
+        if ctx.invoked_subcommand is not None:
+            return dl(ctx, **kwargs)
+
+        # Handle interactive mode
+        if kwargs.get("interactive"):
+            from unshackle.core.interactive import run_service_selector
+            from rich.prompt import Prompt
+            
+            selected_service = run_service_selector()
+            if not selected_service:
+                return
+
+            kwargs['tag'] = selected_service
+            dl(ctx, **kwargs)
+            
+            console.print(Padding(Rule(f"[rule.text]Enter URL or ID for {selected_service}"), (1, 2)))
+            content_id = Prompt.ask(f"   [bold cyan]URL/ID[/]").strip()
+            
+            if not content_id:
+                raise click.UsageError("Content ID/URL is required.")
+
+            # Load the service command and prompt for its specific options
+            service_cmd = Services.load(selected_service)
+            from unshackle.core.interactive import run_service_extra_options
+            service_kwargs = run_service_extra_options(service_cmd, ctx)
+
+            # Normalize interactive prompt outputs to match standard CLI types
+            for k, v in service_kwargs.items():
+                if isinstance(v, list):
+                    v = v[0] if v else None
+                if hasattr(v, 'value'):
+                    v = v.value
+                service_kwargs[k] = v
+
+            # Resolve the main argument name (typically the content URL/ID)
+            params = getattr(service_cmd.cli, "params", [])
+            arg_name = next((p.name for p in params if isinstance(p, click.Argument)), "title")
+            
+            # Sync context params so they are accessible during dl.result()
+            ctx.params.update(service_kwargs)
+            
+            result_service = ctx.invoke(service_cmd.cli, **{arg_name: content_id, **service_kwargs})
+            
+            if result_service is None:
+                import logging
+                logging.getLogger("download").error(f"Failed to initialize service: {selected_service}")
+                return
+
+            return result_service
+
+        # Show help if no subcommand or interactive flag was provided
+        click.echo(ctx.get_help())
+        ctx.exit()
 
     DRM_TABLE_LOCK = Lock()
     EXPORT_LOCK = Lock()
@@ -729,8 +792,9 @@ class dl:
         *_: Any,
         **__: Any,
     ):
-        if not ctx.invoked_subcommand:
-            raise ValueError("A subcommand to invoke was not specified, the main code cannot continue.")
+        sub_cmd = ctx.invoked_subcommand or tag
+        if not sub_cmd:
+            raise ValueError("A subcommand or tag to invoke was not specified, the main code cannot continue.")
 
         self.log = logging.getLogger("download")
         self.completed_files: list[Path] = []
@@ -749,7 +813,7 @@ class dl:
                 "See unshackle-example.yaml for examples."
             )
 
-        self.service = Services.get_tag(ctx.invoked_subcommand)
+        self.service = Services.get_tag(sub_cmd)
         self.vault_service = Services.get_vault_tag(self.service)
         apply_service_dl_overrides(ctx, config.services.get(self.service, {}).get("dl", {}), self.log)
 
@@ -1190,6 +1254,7 @@ class dl:
         no_video: bool,
         audio_description: bool,
         slow: Optional[tuple[int, int]],
+        interactive: bool,
         list_: bool,
         list_titles: bool,
         skip_dl: bool,
@@ -1368,6 +1433,55 @@ class dl:
                 self.debug_logger.log(
                     level="INFO", operation="get_titles", service=self.service, context={"titles": titles_info}
                 )
+
+        # Handle interactive parameter refinement
+        if interactive:
+            from unshackle.core.interactive import run_interactive_session
+            from unshackle.core.constants import DOWNLOAD_LICENCE_ONLY
+            
+            # Filter current local scope variables to pass as default session parameters
+            exclude = {'self', 'service', 'titles', 'start_time', 'ctx', 'log', 'exclude'}
+            current_params = {k: v for k, v in locals().items() if k not in exclude and not k.startswith('_')}
+
+            # Execute session selection
+            selections = run_interactive_session(service, titles, self.log, current_params)
+            
+            # Apply selection results to local configuration variables
+            quality = selections.get('quality', quality)
+            vcodec = selections.get('vcodec', vcodec)
+            acodec = selections.get('acodec', acodec)
+            range_ = selections.get('range_', range_)
+            a_lang = selections.get('a_lang', a_lang)
+            s_lang = selections.get('s_lang', s_lang)
+            vbitrate = selections.get('vbitrate', vbitrate)
+            abitrate = selections.get('abitrate', abitrate)
+            
+            no_mux = selections.get('no_mux', no_mux)
+            list_ = selections.get('list_', list_)
+            export = selections.get('export', export)
+            if export:
+                config.directories.exports.mkdir(parents=True, exist_ok=True)
+                export_path = config.directories.exports / f"export_{self.service}_{int(time.time())}.json"
+                self.export_service = service            
+            list_titles = selections.get('list_titles', list_titles)
+            forced_subs = selections.get('forced_subs', forced_subs)
+            audio_description = selections.get('audio_description', audio_description)
+            skip_dl = selections.get('skip_dl', skip_dl)
+            no_subs = selections.get('no_subs', no_subs)
+            latest_episode = selections.get('latest_episode', latest_episode)
+            worst = selections.get('v_mode', 'best') == 'worst'
+            select_titles = selections.get('select_titles', select_titles)
+
+            # Update licence-only state based on final selection
+            if skip_dl:
+                DOWNLOAD_LICENCE_ONLY.set()
+            else:
+                DOWNLOAD_LICENCE_ONLY.clear()
+
+            # Default language tracks to 'all' to bypass strict filtering
+            v_lang = ["all"]
+            if not a_lang:
+                a_lang = ["all"]
 
         title_cacher = service.title_cache if hasattr(service, "title_cache") else None
         cache_title_id = None

--- a/unshackle/core/config.py
+++ b/unshackle/core/config.py
@@ -69,6 +69,7 @@ class Config:
         self.credentials: dict = kwargs.get("credentials") or {}
         self.firefox_cookies: dict = kwargs.get("firefox_cookies") or {}
         self.subtitle: dict = kwargs.get("subtitle") or {}
+        self.interactive: dict = kwargs.get("interactive") or {}
 
         self.directories = self._Directories()
         for name, path in (kwargs.get("directories") or {}).items():

--- a/unshackle/core/interactive.py
+++ b/unshackle/core/interactive.py
@@ -1,0 +1,685 @@
+import sys
+import math
+import click
+from click.core import ParameterSource
+from typing import List, Dict, Any, Optional
+
+from rich.tree import Tree
+from rich.text import Text
+from rich.prompt import Prompt, Confirm
+from rich.rule import Rule
+from rich.table import Table
+from rich.padding import Padding
+
+from unshackle.core.console import console
+from unshackle.core.tracks import Video, Audio
+from unshackle.core.config import config
+from unshackle.core.utils.selector import Selector
+from unshackle.core.services import Services
+from unshackle.core.titles import Series
+
+class BitrateMatcher(int):
+    """Utility class to match stream bitrates within a specified tolerance range."""
+    def __new__(cls, target_bps, tolerance=0.25, *args, **kwargs):
+        base_val = target_bps[0] if isinstance(target_bps, list) else target_bps
+        return super(BitrateMatcher, cls).__new__(cls, base_val // 1000)
+
+    def __init__(self, target_bps: int, tolerance=0.25):
+        self.target_bps = target_bps
+        self.targets = target_bps if isinstance(target_bps, list) else [target_bps]
+        self.tolerance = tolerance
+
+    def __eq__(self, other):
+        if other is None:
+            return False
+        try:
+            val = float(other)
+            # Normalize scale differences (bps vs. kbps)
+            actual_bps = val if val > 100000 else val * 1000
+            
+            for target in self.targets:
+                if abs(actual_bps - target) <= (target * self.tolerance):
+                    return True
+            return False
+        except (ValueError, TypeError):
+            return False
+
+def run_service_selector() -> str:
+    """Displays a numbered list of available services and returns the selected tag."""
+    tags = [t for t in Services.get_tags() if t != "EXAMPLE"]
+    
+    if not tags:
+        console.print("[bold red]Error: No active services found![/]")
+        sys.exit(1)
+
+    console.print(Padding(Rule("[rule.text]Select Available Service"), (0, 2, 1, 2)))
+    
+    num_tags = len(tags)
+    num_cols = 4
+    num_rows = math.ceil(num_tags / num_cols)
+    
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    for _ in range(num_cols):
+        table.add_column()
+
+    for r in range(num_rows):
+        row_cells = []
+        for c in range(num_cols):
+            # Map index to column-major order (vertical sorting)
+            idx = r + (c * num_rows)
+            if idx < num_tags:
+                row_cells.append(f"[bold magenta]{idx + 1:2}[/] - {tags[idx]}")
+            else:
+                row_cells.append("")
+        table.add_row(*row_cells)
+    
+    console.print(table)
+    
+    idx_str = Prompt.ask(
+        "\n  [bold]Select Service Index[/]", 
+        choices=[str(i) for i in range(1, num_tags + 1)], 
+        show_choices=False
+    )
+    console.print()
+    return tags[int(idx_str) - 1]
+
+def parse_indices(input_str: str, max_val: int) -> List[int]:
+    """Parses user input string (e.g. '1-3, 5') into 0-based indices."""
+    indices = set()
+    parts = input_str.replace(',', ' ').split()
+    
+    for part in parts:
+        if '-' in part:
+            try:
+                nums = list(map(int, part.split('-')))
+                # Support reversed ranges (e.g., '3-1')
+                start, end = min(nums), max(nums)
+                for i in range(start, end + 1):
+                    if 1 <= i <= max_val:
+                        indices.add(i - 1)
+            except ValueError:
+                continue
+        else:
+            try:
+                i = int(part)
+                if 1 <= i <= max_val:
+                    indices.add(i - 1)
+            except ValueError:
+                continue
+    return sorted(list(indices))
+
+
+def get_standard_quality_tier(v: Any) -> int:
+    """Maps heights to standard engine quality tiers."""
+    h = getattr(v, 'height', 0)
+    
+    if h > 1500:
+        return 2160
+    if h > 800:
+        return 1080
+    if h > 600:
+        return 720
+    if h > 0:
+        return 480
+
+    return h
+
+def run_service_extra_options(service_cmd: Any, ctx: Any) -> Dict[str, Any]:
+    service_kwargs = {}
+    
+    # Exclude parameters that are managed globally by the interactive engine
+    global_engine_params = [
+        'vcodec', 'video_codec', 'acodec', 'audio_codec', 
+        'quality', 'range_', 'title', 'url', 'help', 'interactive'
+    ]
+
+    params = getattr(service_cmd.cli, "params", [])
+    if not params:
+        return service_kwargs
+
+    interactive_params = []
+    for param in params:
+        if not isinstance(param, click.Option) or param.name in global_engine_params:
+            continue
+        
+        # Bypass interactive prompt if option was already specified in the CLI
+        source = ctx.get_parameter_source(param.name)
+        if source == ParameterSource.COMMANDLINE:
+            service_kwargs[param.name] = ctx.params.get(param.name)
+            continue
+
+        # Filter for options suitable for interactive prompt configuration
+        if isinstance(param.type, click.Choice) or param.is_flag or param.default is not None:
+            interactive_params.append(param)
+
+    if not interactive_params:
+        return service_kwargs
+
+    # Prompt user whether to configure service-specific options
+    console.print(Padding(Rule("[rule.text]Service Specific Options"), (0, 2, 1, 2)))
+    
+    msg = f"  [bold cyan]{len(interactive_params)}[/] service-specific options available. Configure them?"
+    if not Confirm.ask(msg, default=False):
+        return service_kwargs
+
+    # Interactive options setup
+    for param in interactive_params:
+        param_label = param.name.replace('_', ' ').title()
+        
+        if param.help:
+            console.print(f"\n  [bold yellow]󰋖[/] [white]{param.help}[/]")
+
+        # Handle Click Choice options
+        if isinstance(param.type, click.Choice):
+            choices = param.type.choices
+            for i, choice in enumerate(choices, 1):
+                is_default = " [dim](default)[/]" if choice == param.default else ""
+                console.print(f"    [bold magenta]{i:2}[/] - {choice}{is_default}")
+            
+            default_idx = "1"
+            if param.default in choices:
+                default_idx = str(choices.index(param.default) + 1)
+
+            idx_str = Prompt.ask(
+                f"\n  Select [bold cyan]{param_label}[/] Index",
+                choices=[str(i) for i in range(1, len(choices) + 1)],
+                default=default_idx,
+                show_choices=False
+            )
+            service_kwargs[param.name] = choices[int(idx_str) - 1]
+
+        # Handle Boolean flags
+        elif param.is_flag:
+            service_kwargs[param.name] = Confirm.ask(
+                f"  Enable [bold cyan]{param_label}[/]?",
+                default=param.default
+            )
+
+        # Handle standard text/numeric options with a default value
+        else:
+            service_kwargs[param.name] = Prompt.ask(
+                f"  Enter [bold cyan]{param_label}[/]",
+                default=str(param.default)
+            )
+                
+    return service_kwargs
+
+def run_interactive_session(service: Any, titles: Any, log: Any, current_params: Dict[str, Any] = None) -> Dict[str, Any]:
+    int_cfg = getattr(config, "interactive", {})
+    params = current_params or {}
+    
+    is_series = isinstance(titles, (Series, list)) and not hasattr(titles, 'name')
+    
+    behavior_map = [
+        ("Disable Muxing", "no_mux"),
+        ("Forced Subtitles Only", "forced_subs"),
+        ("Include Audio Description", "audio_description"),
+        ("Skip Download (Retrieve Keys Only)", "skip_dl"),
+        ("Dry Run (List Tracks Only)", "list_"),
+        ("Export Session to JSON", "export")
+    ]
+    
+    if is_series:
+        behavior_map.append(("Latest Episode Only", "latest_episode"))
+    
+    selector = Selector(
+        options=[opt[0] for opt in behavior_map], 
+        cursor_style="cyan", 
+        page_size=len(behavior_map)
+    )
+    
+    # Enforce priority: configuration settings and CLI arguments override defaults
+    for idx, (label, key) in enumerate(behavior_map):
+        should_be_checked = False
+        if int_cfg.get(key) is True:
+            should_be_checked = True
+        if params.get(key) is True:
+            should_be_checked = True
+        if should_be_checked:
+            selector.selected_indices.add(idx)
+    
+    console.print(Padding(Rule("[rule.text]Phase 1: Customizations"), (1, 2, 1, 2)))
+    selected_indices = selector.run()
+    
+    if selected_indices is None:
+        sys.exit(0)
+    
+    selections = {
+        "quality": [], 
+        "vcodec": [], 
+        "range_": [], 
+        "vbitrate": None, 
+        "v_mode": "best",
+        "a_lang": [], 
+        "s_lang": [], 
+        "select_titles": True, 
+        "no_subs": False,
+        "latest_episode": False,
+    }
+    
+    for idx, (label, key) in enumerate(behavior_map):
+        selections[key] = idx in selected_indices
+
+    for label, key in behavior_map:
+        icon = "[bold green]✓[/]" if selections[key] else "[dim] [/]"
+        style = "bold green" if selections[key] else "dim"
+        console.print(f"  {icon} [{style}]{label}[/]")
+
+    # Early exit if dry run (list-only) mode is enabled
+    if selections.get("list_"):
+        return selections
+
+    try:
+        # Phase 2: Reference title selection for track previewing
+        is_multi_input = hasattr(titles, "__iter__") and len(titles) > 1
+        
+        if is_multi_input and not selections["latest_episode"]:
+            console.print(Padding(Rule("[rule.text]Phase 2: Reference Title Selection"), (1, 2, 1, 2)))
+            
+            season_data = {}
+            for idx, t in enumerate(titles):
+                s_num = getattr(t, 'season', 'Unknown')
+                if s_num not in season_data:
+                    season_data[s_num] = {"start": idx + 1, "count": 0}
+                season_data[s_num]["count"] += 1
+            
+            milestones = []
+            for s_num, data in season_data.items():
+                start = data["start"]
+                end = start + data["count"] - 1
+                milestones.append(f"  S{s_num:<2} [dim]({start}-{end})[/]")
+
+            m_table = Table(show_header=False, box=None, padding=(0, 2))
+            for _ in range(3):
+                m_table.add_column(no_wrap=True)
+
+            m_rows = math.ceil(len(milestones) / 3)
+            for r in range(m_rows):
+                row_cells = []
+                for c in range(3):
+                    idx = r + (c * m_rows)
+                    if idx < len(milestones):
+                        row_cells.append(milestones[idx])
+                    else:
+                        row_cells.append("")
+                m_table.add_row(*row_cells)
+            
+            console.print("  [dim]Pick a number as a reference to preview tracks.[/]\n")
+            console.print(m_table)
+            
+            ref_idx = int(Prompt.ask(
+                "\n  Enter Reference Index", 
+                choices=[str(i) for i in range(1, len(titles) + 1)], 
+                default="1", 
+                show_choices=False
+            )) - 1
+            target = titles[ref_idx]
+            header_text = f"Track Info: {target}"
+        else:
+            if is_multi_input and selections["latest_episode"]:
+                target = titles[-1]
+            else:
+                target = titles[0] if hasattr(titles, "__iter__") else titles
+            header_text = f"Track Info: {target}"
+
+        # Fetch metadata to populate track selection options
+        console.print(Padding(Rule(header_text), (1, 2, 1, 2)))
+        with console.status("[bold cyan]Fetching metadata...[/]"):
+            fetched = service.get_tracks(target)
+            if fetched:
+                if not hasattr(target, 'tracks') or target.tracks is None:
+                    target.tracks = fetched
+                else:
+                    target.tracks.add(fetched, warn_only=True)
+
+        # Phase 3: Video filtering based on available codecs and dynamic range
+        console.print(Padding(Rule("[rule.text]Phase 3: Video Filters"), (0, 2, 1, 2)))
+        v_pool = target.tracks.videos
+
+        # Filter by video codec
+        codecs = list(Video.Codec)
+        codec_options = [f"[bold white]  1. Any / Default [/] [[bold white]{len(v_pool):>3}[/]]"]
+        for idx, c in enumerate(codecs, 2):
+            count = len([v for v in v_pool if v.codec == c])
+            style = "white" if count > 0 else "dim"
+            label = f"{c.name} ({c.value})"
+            codec_options.append(f"[{style}] {idx:2}. {label:<14}[/] [[bold]{count:>3}[/]]")
+            
+        c_table = Table(show_header=False, box=None, padding=(0, 1))
+        for _ in range(2):
+            c_table.add_column()
+        c_rows = math.ceil(len(codec_options) / 2)
+        for r in range(c_rows):
+            row_cells = []
+            for c in range(2):
+                idx = r + (c * c_rows)
+                if idx < len(codec_options):
+                    row_cells.append(codec_options[idx])
+                else:
+                    row_cells.append("")
+            c_table.add_row(*row_cells)
+            
+        console.print(" [bold cyan]Select Video Codec Filter:[/]")
+        console.print(c_table)
+        f_idx_str = Prompt.ask("\n  Select Codec Index", choices=[str(i) for i in range(1, len(codec_options) + 1)], default="1", show_choices=False)
+        if f_idx_str != "1":
+            selected_codec = codecs[int(f_idx_str) - 2]
+            selections["vcodec"] = [selected_codec]
+            service.track_request.codecs = selections["vcodec"]
+            # Narrow down video pool for subsequent range filters
+            v_pool = [v for v in v_pool if v.codec == selected_codec]
+
+        # Filter by video dynamic range
+        ranges = list(Video.Range)
+        range_options = [f"[bold white]  1. Any / Default [/] [[bold white]{len(v_pool):>3}[/]]"]
+        for idx, r in enumerate(ranges, 2):
+            count = len([v for v in v_pool if v.range == r])
+            style = "white" if count > 0 else "dim"
+            label = r.name
+            range_options.append(f"[{style}] {idx:2}. {label:<14}[/] [[bold]{count:>3}[/]]")
+
+        r_table = Table(show_header=False, box=None, padding=(0, 2))
+        for _ in range(2):
+            r_table.add_column()
+        r_rows = math.ceil(len(range_options) / 2)
+        for r in range(r_rows):
+            row_cells = []
+            for c in range(2):
+                idx = r + (c * r_rows)
+                if idx < len(range_options):
+                    row_cells.append(range_options[idx])
+                else:
+                    row_cells.append("")
+            r_table.add_row(*row_cells)
+            
+        console.print("\n [bold cyan]Select Dynamic Range Filter:[/]")
+        console.print(r_table)
+        r_idx_str = Prompt.ask(
+            "\n  Select Range Index", 
+            choices=[str(i) for i in range(1, len(range_options) + 1)], 
+            default="1", 
+            show_choices=False
+        )
+        if r_idx_str != "1":
+            selected_range = ranges[int(r_idx_str) - 2]
+            selections["range_"] = [selected_range]
+
+        # Phase 4: Video track selection
+        display_v = target.tracks.videos
+        if selections.get("vcodec"):
+            display_v = [v for v in display_v if v.codec in selections["vcodec"]]
+        if selections.get("range_"):
+            display_v = [v for v in display_v if v.range in selections["range_"]]
+
+        v_tree = Tree("\n[bold cyan]Available Video Tracks:[/]", guide_style="dim")
+        range_priority = {"SDR": 0, "HDR10": 1, "DV": 2}
+        codec_priority = {"AVC": 0, "HEVC": 1, "AV1": 2}
+
+        def get_range_val(t):
+            if getattr(t, 'dv', False): return "DV"
+            if getattr(t, 'hdr10', False): return "HDR10"
+            return str(t.range).split('.')[-1]
+
+        def get_codec_val(t):
+            return str(t.codec).split('.')[-1]
+
+        # Sort by: Height -> Width -> Range priority -> Codec priority -> Bitrate
+        display_v = sorted(display_v, key=lambda x: (
+            x.height, 
+            x.width, 
+            range_priority.get(get_range_val(x), 0), 
+            codec_priority.get(get_codec_val(x), 9),
+            x.bitrate or 0
+        ))
+
+        codec_colors = {"AVC": "green", "HEVC": "yellow", "AV1": "cyan"}
+        range_colors = {"SDR": "dim", "HDR10": "bold orange1", "DV": "bold magenta"}
+
+        last_tier = None
+        current_branch = v_tree
+
+        for i, t in enumerate(display_v, 1):
+            current_tier = f"{t.width}x{t.height}" if t.width else f"{t.height}p"
+            if current_tier != last_tier:
+                current_branch = v_tree.add(f"[bold rgb(21,131,209)]── {current_tier} ──[/]")
+                last_tier = current_tier
+
+            codec_name = get_codec_val(t)
+            c_style = codec_colors.get(codec_name, "white")
+            v_range = get_range_val(t)
+            r_style = range_colors.get(v_range, "white")
+            fps_str = f", {t.fps:.3f} FPS" if getattr(t, 'fps', None) else ""
+            
+            label = Text.assemble(
+                (f" {i:3} - ", "white"), 
+                ("[", "bold white"), 
+                (f"{codec_name:<4}", c_style),
+                (" | ", "bold white"), 
+                (f"{v_range:<5}", r_style), 
+                ("]", "bold white"),
+                (f" @ {t.bitrate//1000:>5}kbps{fps_str}", "white")
+            )
+            current_branch.add(label)
+        
+        console.print(v_tree)
+        
+        v_idx = int(Prompt.ask("\n  Select Video Index", default="1")) - 1
+        v_sel = display_v[v_idx]
+        
+        is_single_output = not is_multi_input or selections["latest_episode"]
+        
+        # Calculate dl.py-compatible quality resolution height mapping
+        magic_quality = int(v_sel.width * 9 / 16)
+        
+        selections["vcodec"] = [v_sel.codec]
+        selections["range_"] = [v_sel.range]
+        selections["quality"] = [magic_quality]
+
+        if is_single_output:
+            selections["v_mode"] = "exact"
+            selections["vbitrate"] = BitrateMatcher(v_sel.bitrate, tolerance=0.05)
+        else:
+            # Determine profile position for batch mode stability
+            profile_tracks = sorted(
+                [
+                    v for v in display_v 
+                    if v.height == v_sel.height and v.width == v_sel.width 
+                    and v.codec == v_sel.codec and v.range == v_sel.range
+                ], 
+                key=lambda x: x.bitrate, 
+                reverse=True
+            )
+            
+            selections["vbitrate"] = None  # Prevent strict bitrate matching in batch mode
+            if v_sel.bitrate == profile_tracks[0].bitrate:
+                selections["v_mode"] = "best"
+            else:
+                selections["v_mode"] = "worst"
+
+        # Phase 5: Audio filtering
+        console.print(Padding(Rule("[rule.text]Phase 5: Audio Filters"), (1, 2, 1, 2)))
+        from unshackle.core.tracks import Audio
+        
+        a_pool = target.tracks.audio
+        
+        # Filter out descriptive tracks early if not explicitly requested
+        if not selections.get("audio_description"):
+            a_pool = [a for a in a_pool if not getattr(a, 'descriptive', False)]
+
+        # Filter by audio codec
+        a_codecs = list(Audio.Codec)
+        a_codec_options = [f"[bold white]  1. Any / Default [/] [[bold white]{len(a_pool):>3}[/]]"]
+        
+        for idx, c in enumerate(a_codecs, 2):
+            count = len([a for a in a_pool if a.codec == c])
+            style = "white" if count > 0 else "dim"
+            label = f"{c.name} ({c.value})"
+            a_codec_options.append(f"[{style}] {idx:2}. {label:<14}[/] [[bold]{count:>3}[/]]")
+            
+        ac_table = Table(show_header=False, box=None, padding=(0, 1))
+        for _ in range(2):
+            ac_table.add_column()
+
+        ac_rows = math.ceil(len(a_codec_options) / 2)
+        for r in range(ac_rows):
+            row_cells = []
+            for c in range(2):
+                idx = r + (c * ac_rows)
+                if idx < len(a_codec_options):
+                    row_cells.append(a_codec_options[idx])
+                else:
+                    row_cells.append("")
+            ac_table.add_row(*row_cells)
+            
+        console.print(" [bold green]Select Audio Codec Filter:[/]")
+        console.print(ac_table)
+        
+        af_idx_str = Prompt.ask("\n  Select Audio Codec Index", choices=[str(i) for i in range(1, len(a_codec_options) + 1)], default="1", show_choices=False)
+        if af_idx_str != "1":
+            selected_a_codec = a_codecs[int(af_idx_str) - 2]
+            selections["acodec"] = [selected_a_codec]
+            a_pool = [a for a in a_pool if a.codec == selected_a_codec]
+
+        # Phase 5.5: Audio track selection
+        if a_pool:
+            display_a = a_pool
+            
+            # Sort by: Original language first -> Language alphabetical -> Channels -> Bitrate
+            display_a = sorted(display_a, key=lambda x: (
+                not getattr(x, 'is_original_lang', False),
+                str(x.language),
+                float(x.channels or 0),
+                x.bitrate or 0
+            ))
+            
+            a_tree = Tree("\n[bold green]Available Audio Tracks:[/]", guide_style="dim")
+            last_lang = None
+            current_branch = a_tree
+
+            for i, t in enumerate(display_a, 1):
+                lang_str = str(t.language).upper()
+                
+                if lang_str != last_lang:
+                    is_orig = getattr(t, 'is_original_lang', False)
+                    orig_tag = " [yellow](Original)[/]" if is_orig else ""
+                    current_branch = a_tree.add(f"[bold rgb(21,131,209)]── {lang_str}{orig_tag} ──[/]")
+                    last_lang = lang_str
+
+                codec_label = t.codec.value if hasattr(t.codec, 'value') else str(t.codec).split('.')[-1]
+                
+                tags = []
+                if getattr(t, 'atmos', False): tags.append("Atmos")
+                if getattr(t, 'descriptive', False): tags.append("AD")
+                
+                # Safe channel count retrieval
+                try:
+                    channels_str = f"{float(t.channels):.1f}" if t.channels is not None else "2.0"
+                except (ValueError, TypeError):
+                    channels_str = "2.0"
+                
+                parts = [
+                    (f" {i:3} - ", "white"), 
+                    ("[", "bold white"), 
+                    (f"{codec_label:<4}", "cyan"), 
+                    ("]", "bold white"),
+                    (f" {channels_str} ch | {t.bitrate//1000 if t.bitrate else 'VBR'}kbps", "white")
+                ]
+                if tags:
+                    parts.append((f" ({', '.join(tags)})", "dim"))
+                
+                current_branch.add(Text.assemble(*parts))
+            
+            console.print(a_tree)
+            
+            # Handle track selection and prevent engine crashes from duplicates
+            a_input = Prompt.ask("\n  Select Audio indices (eg.: 2 6-9)", default="1")
+            a_idxs = parse_indices(a_input, len(display_a))
+            
+            selected_raw = [display_a[i] for i in a_idxs]
+            unique_map = {}
+            seen_combos = set()
+            
+            for t in selected_raw:
+                # Deduplicate based on base language (e.g., prevent es-419 vs es-ES collisions)
+                lang_base = str(t.language).split('-')[0].split('_')[0].lower()
+                combo = (lang_base, t.bitrate)
+                
+                if combo not in seen_combos:
+                    unique_map[combo] = t
+                    seen_combos.add(combo)
+                else:
+                    # Prioritize descriptive audio tracks over standard duplicate requests
+                    if getattr(t, 'descriptive', False) and not getattr(unique_map[combo], 'descriptive', False):
+                        unique_map[combo] = t
+                        log.info(f"Prioritizing AD track for {t.language}")
+                    else:
+                        log.warning(f"Skipping duplicate audio request to prevent engine crash: {t.language}")
+
+            unique_tracks = list(unique_map.values())
+            selections["a_lang"] = [str(t.language) for t in unique_tracks]
+            selections["acodec"] = list(set(t.codec for t in unique_tracks))
+            
+            if any(getattr(t, 'descriptive', False) for t in unique_tracks):
+                selections["audio_description"] = True
+            
+            a_bitrates = [t.bitrate for t in unique_tracks if getattr(t, 'bitrate', None)]
+            if a_bitrates:
+                selections["abitrate"] = BitrateMatcher(list(set(a_bitrates)))
+
+        # Phase 6: Subtitles
+        if not selections["skip_dl"] and target.tracks.subtitles:
+            display_s = sorted(target.tracks.subtitles, key=lambda x: str(x.language))
+            
+            console.print(Padding(Rule("[rule.text]Phase 6: Available Subtitle Tracks"), (1, 2, 1, 2)))
+            
+            s_table = Table(show_header=False, box=None, padding=(0, 2))
+            for _ in range(3):
+                s_table.add_column(no_wrap=True)
+            
+            items = []
+            for i, t in enumerate(display_s, 1):
+                tags = []
+                if getattr(t, 'forced', False): tags.append("Forced")
+                if getattr(t, 'sdh', False) or getattr(t, 'cc', False): tags.append("SDH")
+                
+                tag_str = ""
+                if tags:
+                    tag_str = f" [dim]({', '.join(tags)})[/]"
+                items.append(f"  {i:2} - {t.language}{tag_str}")
+
+            s_rows = math.ceil(len(items) / 3)
+            for r in range(s_rows):
+                row_cells = []
+                for c in range(3):
+                    idx = r + (c * s_rows)
+                    if idx < len(items):
+                        row_cells.append(items[idx])
+                    else:
+                        row_cells.append("")
+                s_table.add_row(*row_cells)
+            
+            console.print(s_table)
+            
+            s_input = Prompt.ask("\n  Select Subtitle indices (eg.: 2 6-9 or ENTER for none)", default="")
+            if s_input:
+                s_idxs = parse_indices(s_input, len(display_s))
+                for i in s_idxs:
+                    if getattr(display_s[i], 'forced', False):
+                        selections["forced_subs"] = True
+                selections["s_lang"] = list(set(str(display_s[i].language) for i in s_idxs))
+
+        # Prepare selections for engine delivery
+        selections["v_lang"] = ["all"]
+        if not selections["a_lang"]:
+            selections["a_lang"] = ["all"]
+            
+        selections["no_subs"] = not bool(selections["s_lang"])
+        
+        if selections.get("latest_episode", False):
+            selections["select_titles"] = False
+
+        return selections
+
+    except Exception as e:
+        console.print_exception()
+        sys.exit(1)

--- a/unshackle/core/interactive.py
+++ b/unshackle/core/interactive.py
@@ -1,93 +1,79 @@
-import sys
+from __future__ import annotations
+
 import math
+from typing import Any, Optional
+
 import click
 from click.core import ParameterSource
-from typing import List, Dict, Any, Optional
-
-from rich.tree import Tree
-from rich.text import Text
-from rich.prompt import Prompt, Confirm
-from rich.rule import Rule
 from rich.table import Table
-from rich.padding import Padding
+from rich.text import Text
+from rich.tree import Tree
 
-from unshackle.core.console import console
-from unshackle.core.tracks import Video, Audio
 from unshackle.core.config import config
-from unshackle.core.utils.selector import Selector
+from unshackle.core.console import console
 from unshackle.core.services import Services
-from unshackle.core.titles import Series
+from unshackle.core.titles import Episode, Series
+from unshackle.core.tracks import Audio, Video
+from unshackle.core.utils.selector import Selector, tui_body, tui_confirm, tui_header, tui_prompt
+
 
 class BitrateMatcher(int):
-    """Utility class to match stream bitrates within a specified tolerance range."""
-    def __new__(cls, target_bps, tolerance=0.25, *args, **kwargs):
-        base_val = target_bps[0] if isinstance(target_bps, list) else target_bps
-        return super(BitrateMatcher, cls).__new__(cls, base_val // 1000)
+    """Match stream bitrates within a tolerance range."""
 
-    def __init__(self, target_bps: int, tolerance=0.25):
+    __hash__ = int.__hash__
+
+    def __new__(cls, target_bps: Any, tolerance: float = 0.25, *args: Any, **kwargs: Any) -> BitrateMatcher:
+        base_val = target_bps[0] if isinstance(target_bps, list) else target_bps
+        int_val = (base_val // 1000) if base_val else 0
+        return super().__new__(cls, int_val)
+
+    def __init__(self, target_bps: Any, tolerance: float = 0.25) -> None:
         self.target_bps = target_bps
         self.targets = target_bps if isinstance(target_bps, list) else [target_bps]
         self.tolerance = tolerance
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         if other is None:
             return False
         try:
             val = float(other)
-            # Normalize scale differences (bps vs. kbps)
-            actual_bps = val if val > 100000 else val * 1000
-            
-            for target in self.targets:
-                if abs(actual_bps - target) <= (target * self.tolerance):
-                    return True
-            return False
         except (ValueError, TypeError):
             return False
+        # Engine compares `track.bitrate // 1000` (kbps) against this matcher; targets are bps, so normalise up.
+        actual_bps = val if val > 100000 else val * 1000
+        for target in self.targets:
+            if target is None:
+                continue
+            if abs(actual_bps - target) <= (target * self.tolerance):
+                return True
+        return False
 
 def run_service_selector() -> str:
-    """Displays a numbered list of available services and returns the selected tag."""
+    """Prompts for a service with the same Selector UI as --select-titles and returns the tag."""
     tags = [t for t in Services.get_tags() if t != "EXAMPLE"]
-    
+
     if not tags:
         console.print("[bold red]Error: No active services found![/]")
-        sys.exit(1)
+        raise click.Abort()
 
-    console.print(Padding(Rule("[rule.text]Select Available Service"), (0, 2, 1, 2)))
-    
-    num_tags = len(tags)
-    num_cols = 4
-    num_rows = math.ceil(num_tags / num_cols)
-    
-    table = Table(show_header=False, box=None, padding=(0, 2))
-    for _ in range(num_cols):
-        table.add_column()
+    tui_header("Select Available Service", pad=(0, 2, 1, 2))
 
-    for r in range(num_rows):
-        row_cells = []
-        for c in range(num_cols):
-            # Map index to column-major order (vertical sorting)
-            idx = r + (c * num_rows)
-            if idx < num_tags:
-                row_cells.append(f"[bold magenta]{idx + 1:2}[/] - {tags[idx]}")
-            else:
-                row_cells.append("")
-        table.add_row(*row_cells)
-    
-    console.print(table)
-    
-    idx_str = Prompt.ask(
-        "\n  [bold]Select Service Index[/]", 
-        choices=[str(i) for i in range(1, num_tags + 1)], 
-        show_choices=False
+    selector = Selector(
+        options=tags,
+        cursor_style="cyan",
+        page_size=min(len(tags), 15),
+        single_select=True,
     )
-    console.print()
-    return tags[int(idx_str) - 1]
+    picked = selector.run()
+    if not picked:
+        raise click.Abort()
+    return tags[picked[0]]
 
-def parse_indices(input_str: str, max_val: int) -> List[int]:
+def parse_indices(input_str: str, max_val: int) -> list[int]:
     """Parses user input string (e.g. '1-3, 5') into 0-based indices."""
     indices = set()
     parts = input_str.replace(',', ' ').split()
-    
+
     for part in parts:
         if '-' in part:
             try:
@@ -112,7 +98,7 @@ def parse_indices(input_str: str, max_val: int) -> List[int]:
 def get_standard_quality_tier(v: Any) -> int:
     """Maps heights to standard engine quality tiers."""
     h = getattr(v, 'height', 0)
-    
+
     if h > 1500:
         return 2160
     if h > 800:
@@ -124,12 +110,12 @@ def get_standard_quality_tier(v: Any) -> int:
 
     return h
 
-def run_service_extra_options(service_cmd: Any, ctx: Any) -> Dict[str, Any]:
+def run_service_extra_options(service_cmd: Any, ctx: Any) -> dict[str, Any]:
     service_kwargs = {}
-    
-    # Exclude parameters that are managed globally by the interactive engine
+
+    # Params the interactive engine manages globally; skip them here.
     global_engine_params = [
-        'vcodec', 'video_codec', 'acodec', 'audio_codec', 
+        'vcodec', 'video_codec', 'acodec', 'audio_codec',
         'quality', 'range_', 'title', 'url', 'help', 'interactive'
     ]
 
@@ -141,75 +127,75 @@ def run_service_extra_options(service_cmd: Any, ctx: Any) -> Dict[str, Any]:
     for param in params:
         if not isinstance(param, click.Option) or param.name in global_engine_params:
             continue
-        
-        # Bypass interactive prompt if option was already specified in the CLI
+
+        # Already given on the CLI; skip the prompt.
         source = ctx.get_parameter_source(param.name)
         if source == ParameterSource.COMMANDLINE:
             service_kwargs[param.name] = ctx.params.get(param.name)
             continue
 
-        # Filter for options suitable for interactive prompt configuration
+        # Only options we can prompt for interactively.
         if isinstance(param.type, click.Choice) or param.is_flag or param.default is not None:
             interactive_params.append(param)
 
     if not interactive_params:
         return service_kwargs
 
-    # Prompt user whether to configure service-specific options
-    console.print(Padding(Rule("[rule.text]Service Specific Options"), (0, 2, 1, 2)))
-    
-    msg = f"  [bold cyan]{len(interactive_params)}[/] service-specific options available. Configure them?"
-    if not Confirm.ask(msg, default=False):
+    tui_header("Service Specific Options")
+
+    msg = f"[bold cyan]{len(interactive_params)}[/] service-specific options available. Configure them?"
+    if not tui_confirm(msg, default=False):
         return service_kwargs
 
-    # Interactive options setup
     for param in interactive_params:
         param_label = param.name.replace('_', ' ').title()
-        
+
+        tui_header(param_label, pad=(1, 2, 0, 2))
         if param.help:
-            console.print(f"\n  [bold yellow]󰋖[/] [white]{param.help}[/]")
+            tui_body(param.help)
 
-        # Handle Click Choice options
         if isinstance(param.type, click.Choice):
-            choices = param.type.choices
-            for i, choice in enumerate(choices, 1):
-                is_default = " [dim](default)[/]" if choice == param.default else ""
-                console.print(f"    [bold magenta]{i:2}[/] - {choice}{is_default}")
-            
-            default_idx = "1"
-            if param.default in choices:
-                default_idx = str(choices.index(param.default) + 1)
+            choices = list(param.type.choices)
+            default_idx = choices.index(param.default) if param.default in choices else 0
+            options = [f"{c}[dim] (default)[/]" if c == param.default else c for c in choices]
 
-            idx_str = Prompt.ask(
-                f"\n  Select [bold cyan]{param_label}[/] Index",
-                choices=[str(i) for i in range(1, len(choices) + 1)],
-                default=default_idx,
-                show_choices=False
+            selector = Selector(
+                options=options,
+                cursor_style="cyan",
+                page_size=min(len(options), 8),
+                single_select=True,
             )
-            service_kwargs[param.name] = choices[int(idx_str) - 1]
+            selector.cursor_index = default_idx
 
-        # Handle Boolean flags
+            picked = selector.run()
+            chosen = picked[0] if picked else default_idx
+            service_kwargs[param.name] = choices[chosen]
+
         elif param.is_flag:
-            service_kwargs[param.name] = Confirm.ask(
-                f"  Enable [bold cyan]{param_label}[/]?",
-                default=param.default
-            )
+            selector = Selector(options=[param_label], cursor_style="cyan", page_size=1)
+            if param.default is True:
+                selector.selected_indices.add(0)
+            service_kwargs[param.name] = 0 in set(selector.run())
 
-        # Handle standard text/numeric options with a default value
         else:
-            service_kwargs[param.name] = Prompt.ask(
-                f"  Enter [bold cyan]{param_label}[/]",
+            service_kwargs[param.name] = tui_prompt(
+                f"Enter [bold cyan]{param_label}[/]",
                 default=str(param.default)
             )
-                
+
     return service_kwargs
 
-def run_interactive_session(service: Any, titles: Any, log: Any, current_params: Dict[str, Any] = None) -> Dict[str, Any]:
+def run_interactive_session(
+    service: Any, titles: Any, log: Any, current_params: Optional[dict[str, Any]] = None
+) -> dict[str, Any]:
     int_cfg = getattr(config, "interactive", {})
     params = current_params or {}
-    
-    is_series = isinstance(titles, (Series, list)) and not hasattr(titles, 'name')
-    
+
+    # Detect episodes explicitly; Movies is a list subclass and must not count as a series
+    is_series = isinstance(titles, Series)
+    if not is_series and isinstance(titles, (list, tuple)):
+        is_series = any(isinstance(t, Episode) for t in titles)
+
     behavior_map = [
         ("Disable Muxing", "no_mux"),
         ("Forced Subtitles Only", "forced_subs"),
@@ -218,17 +204,17 @@ def run_interactive_session(service: Any, titles: Any, log: Any, current_params:
         ("Dry Run (List Tracks Only)", "list_"),
         ("Export Session to JSON", "export")
     ]
-    
+
     if is_series:
         behavior_map.append(("Latest Episode Only", "latest_episode"))
-    
+
     selector = Selector(
-        options=[opt[0] for opt in behavior_map], 
-        cursor_style="cyan", 
+        options=[opt[0] for opt in behavior_map],
+        cursor_style="cyan",
         page_size=len(behavior_map)
     )
-    
-    # Enforce priority: configuration settings and CLI arguments override defaults
+
+    # Config and CLI args override defaults
     for idx, (label, key) in enumerate(behavior_map):
         should_be_checked = False
         if int_cfg.get(key) is True:
@@ -237,59 +223,56 @@ def run_interactive_session(service: Any, titles: Any, log: Any, current_params:
             should_be_checked = True
         if should_be_checked:
             selector.selected_indices.add(idx)
-    
-    console.print(Padding(Rule("[rule.text]Phase 1: Customizations"), (1, 2, 1, 2)))
+
+    tui_header("Phase 1: Customizations")
     selected_indices = selector.run()
-    
+
     if selected_indices is None:
-        sys.exit(0)
-    
+        raise click.Abort()
+
     selections = {
-        "quality": [], 
-        "vcodec": [], 
-        "range_": [], 
-        "vbitrate": None, 
+        "quality": [],
+        "vcodec": [],
+        "range_": [],
+        "vbitrate": None,
         "v_mode": "best",
-        "a_lang": [], 
-        "s_lang": [], 
-        "select_titles": True, 
+        "acodec": [],
+        "abitrate": None,
+        "a_lang": [],
+        "s_lang": [],
+        "select_titles": True,
         "no_subs": False,
         "latest_episode": False,
     }
-    
+
     for idx, (label, key) in enumerate(behavior_map):
         selections[key] = idx in selected_indices
 
     for label, key in behavior_map:
         icon = "[bold green]✓[/]" if selections[key] else "[dim] [/]"
         style = "bold green" if selections[key] else "dim"
-        console.print(f"  {icon} [{style}]{label}[/]")
-
-    # Early exit if dry run (list-only) mode is enabled
-    if selections.get("list_"):
-        return selections
+        tui_body(f"{icon} [{style}]{label}[/]")
 
     try:
-        # Phase 2: Reference title selection for track previewing
         is_multi_input = hasattr(titles, "__iter__") and len(titles) > 1
-        
+
         if is_multi_input and not selections["latest_episode"]:
-            console.print(Padding(Rule("[rule.text]Phase 2: Reference Title Selection"), (1, 2, 1, 2)))
-            
+            tui_header("Phase 2: Reference Title Selection")
+
             season_data = {}
             for idx, t in enumerate(titles):
                 s_num = getattr(t, 'season', 'Unknown')
                 if s_num not in season_data:
                     season_data[s_num] = {"start": idx + 1, "count": 0}
                 season_data[s_num]["count"] += 1
-            
+
             milestones = []
             for s_num, data in season_data.items():
                 start = data["start"]
                 end = start + data["count"] - 1
-                milestones.append(f"  S{s_num:<2} [dim]({start}-{end})[/]")
+                milestones.append(f"S{s_num:<2} [dim]({start}-{end})[/]")
 
-            m_table = Table(show_header=False, box=None, padding=(0, 2))
+            m_table = Table(show_header=False, box=None, pad_edge=False, padding=(0, 2))
             for _ in range(3):
                 m_table.add_column(no_wrap=True)
 
@@ -303,14 +286,14 @@ def run_interactive_session(service: Any, titles: Any, log: Any, current_params:
                     else:
                         row_cells.append("")
                 m_table.add_row(*row_cells)
-            
-            console.print("  [dim]Pick a number as a reference to preview tracks.[/]\n")
-            console.print(m_table)
-            
-            ref_idx = int(Prompt.ask(
-                "\n  Enter Reference Index", 
-                choices=[str(i) for i in range(1, len(titles) + 1)], 
-                default="1", 
+
+            tui_body("[dim]Pick a number as a reference to preview tracks.[/]\n")
+            tui_body(m_table)
+
+            ref_idx = int(tui_prompt(
+                "\nEnter Reference Index",
+                choices=[str(i) for i in range(1, len(titles) + 1)],
+                default="1",
                 show_choices=False
             )) - 1
             target = titles[ref_idx]
@@ -322,8 +305,7 @@ def run_interactive_session(service: Any, titles: Any, log: Any, current_params:
                 target = titles[0] if hasattr(titles, "__iter__") else titles
             header_text = f"Track Info: {target}"
 
-        # Fetch metadata to populate track selection options
-        console.print(Padding(Rule(header_text), (1, 2, 1, 2)))
+        tui_header(header_text)
         with console.status("[bold cyan]Fetching metadata...[/]"):
             fetched = service.get_tracks(target)
             if fetched:
@@ -332,20 +314,18 @@ def run_interactive_session(service: Any, titles: Any, log: Any, current_params:
                 else:
                     target.tracks.add(fetched, warn_only=True)
 
-        # Phase 3: Video filtering based on available codecs and dynamic range
-        console.print(Padding(Rule("[rule.text]Phase 3: Video Filters"), (0, 2, 1, 2)))
+        tui_header("Phase 3: Video Filters", pad=(0, 2, 1, 2))
         v_pool = target.tracks.videos
 
-        # Filter by video codec
         codecs = list(Video.Codec)
-        codec_options = [f"[bold white]  1. Any / Default [/] [[bold white]{len(v_pool):>3}[/]]"]
+        codec_options = [f"[bold white] 1. Any / Default [/] [[bold white]{len(v_pool):>3}[/]]"]
         for idx, c in enumerate(codecs, 2):
             count = len([v for v in v_pool if v.codec == c])
             style = "white" if count > 0 else "dim"
             label = f"{c.name} ({c.value})"
-            codec_options.append(f"[{style}] {idx:2}. {label:<14}[/] [[bold]{count:>3}[/]]")
-            
-        c_table = Table(show_header=False, box=None, padding=(0, 1))
+            codec_options.append(f"[{style}]{idx:2}. {label:<14}[/] [[bold]{count:>3}[/]]")
+
+        c_table = Table(show_header=False, box=None, pad_edge=False, padding=(0, 1))
         for _ in range(2):
             c_table.add_column()
         c_rows = math.ceil(len(codec_options) / 2)
@@ -358,27 +338,26 @@ def run_interactive_session(service: Any, titles: Any, log: Any, current_params:
                 else:
                     row_cells.append("")
             c_table.add_row(*row_cells)
-            
-        console.print(" [bold cyan]Select Video Codec Filter:[/]")
-        console.print(c_table)
-        f_idx_str = Prompt.ask("\n  Select Codec Index", choices=[str(i) for i in range(1, len(codec_options) + 1)], default="1", show_choices=False)
+
+        tui_body("[bold cyan]Select Video Codec Filter:[/]")
+        tui_body(c_table)
+        f_idx_str = tui_prompt("\nSelect Codec Index", choices=[str(i) for i in range(1, len(codec_options) + 1)], default="1", show_choices=False)
         if f_idx_str != "1":
             selected_codec = codecs[int(f_idx_str) - 2]
             selections["vcodec"] = [selected_codec]
             service.track_request.codecs = selections["vcodec"]
-            # Narrow down video pool for subsequent range filters
+            # Narrow the pool for the range filter.
             v_pool = [v for v in v_pool if v.codec == selected_codec]
 
-        # Filter by video dynamic range
         ranges = list(Video.Range)
-        range_options = [f"[bold white]  1. Any / Default [/] [[bold white]{len(v_pool):>3}[/]]"]
+        range_options = [f"[bold white] 1. Any / Default [/] [[bold white]{len(v_pool):>3}[/]]"]
         for idx, r in enumerate(ranges, 2):
             count = len([v for v in v_pool if v.range == r])
             style = "white" if count > 0 else "dim"
             label = r.name
-            range_options.append(f"[{style}] {idx:2}. {label:<14}[/] [[bold]{count:>3}[/]]")
+            range_options.append(f"[{style}]{idx:2}. {label:<14}[/] [[bold]{count:>3}[/]]")
 
-        r_table = Table(show_header=False, box=None, padding=(0, 2))
+        r_table = Table(show_header=False, box=None, pad_edge=False, padding=(0, 1))
         for _ in range(2):
             r_table.add_column()
         r_rows = math.ceil(len(range_options) / 2)
@@ -391,20 +370,48 @@ def run_interactive_session(service: Any, titles: Any, log: Any, current_params:
                 else:
                     row_cells.append("")
             r_table.add_row(*row_cells)
-            
-        console.print("\n [bold cyan]Select Dynamic Range Filter:[/]")
-        console.print(r_table)
-        r_idx_str = Prompt.ask(
-            "\n  Select Range Index", 
-            choices=[str(i) for i in range(1, len(range_options) + 1)], 
-            default="1", 
+
+        tui_body("\n[bold cyan]Select Dynamic Range Filter:[/]")
+        tui_body(r_table)
+        r_idx_str = tui_prompt(
+            "\nSelect Range Index",
+            choices=[str(i) for i in range(1, len(range_options) + 1)],
+            default="1",
             show_choices=False
         )
         if r_idx_str != "1":
             selected_range = ranges[int(r_idx_str) - 2]
             selections["range_"] = [selected_range]
 
-        # Phase 4: Video track selection
+        # Dry run still needs codec/range to drive the request; dl lists the tracks itself.
+        if selections.get("list_"):
+            if selections.get("vcodec"):
+                service.track_request.codecs = selections["vcodec"]
+            if selections.get("range_"):
+                service.track_request.ranges = selections["range_"]
+            return selections
+
+        # get_tracks is request-gated, so re-fetch for the chosen codec/range
+        req_codecs = selections.get("vcodec")
+        req_ranges = selections.get("range_")
+        if req_codecs or req_ranges:
+            prev_tracks = target.tracks
+            service.track_request.codecs = req_codecs or []
+            service.track_request.ranges = req_ranges or list(Video.Range)
+            with console.status("[bold cyan]Refetching tracks for selected codec/range...[/]"):
+                refetched = service.get_tracks(target)
+            if refetched:
+                target.tracks = refetched
+            # Fall back to the pre-refetch pool if nothing matched
+            check_v = target.tracks.videos
+            if req_codecs:
+                check_v = [v for v in check_v if v.codec in req_codecs]
+            if req_ranges:
+                check_v = [v for v in check_v if v.range in req_ranges]
+            if not check_v:
+                console.print("[yellow]No video tracks matched that codec/range; showing what was available.[/]")
+                target.tracks = prev_tracks
+
         display_v = target.tracks.videos
         if selections.get("vcodec"):
             display_v = [v for v in display_v if v.codec in selections["vcodec"]]
@@ -415,19 +422,21 @@ def run_interactive_session(service: Any, titles: Any, log: Any, current_params:
         range_priority = {"SDR": 0, "HDR10": 1, "DV": 2}
         codec_priority = {"AVC": 0, "HEVC": 1, "AV1": 2}
 
-        def get_range_val(t):
-            if getattr(t, 'dv', False): return "DV"
-            if getattr(t, 'hdr10', False): return "HDR10"
+        def get_range_val(t: Any) -> str:
+            if getattr(t, 'dv', False):
+                return "DV"
+            if getattr(t, 'hdr10', False):
+                return "HDR10"
             return str(t.range).split('.')[-1]
 
-        def get_codec_val(t):
+        def get_codec_val(t: Any) -> str:
             return str(t.codec).split('.')[-1]
 
         # Sort by: Height -> Width -> Range priority -> Codec priority -> Bitrate
         display_v = sorted(display_v, key=lambda x: (
-            x.height, 
-            x.width, 
-            range_priority.get(get_range_val(x), 0), 
+            x.height or 0,
+            x.width or 0,
+            range_priority.get(get_range_val(x), 0),
             codec_priority.get(get_codec_val(x), 9),
             x.bitrate or 0
         ))
@@ -449,74 +458,78 @@ def run_interactive_session(service: Any, titles: Any, log: Any, current_params:
             v_range = get_range_val(t)
             r_style = range_colors.get(v_range, "white")
             fps_str = f", {t.fps:.3f} FPS" if getattr(t, 'fps', None) else ""
-            
+            bitrate_str = f"{t.bitrate//1000:>5}kbps" if t.bitrate else "  VBR"
+
             label = Text.assemble(
-                (f" {i:3} - ", "white"), 
-                ("[", "bold white"), 
+                (f" {i:3} - ", "white"),
+                ("[", "bold white"),
                 (f"{codec_name:<4}", c_style),
-                (" | ", "bold white"), 
-                (f"{v_range:<5}", r_style), 
+                (" | ", "bold white"),
+                (f"{v_range:<5}", r_style),
                 ("]", "bold white"),
-                (f" @ {t.bitrate//1000:>5}kbps{fps_str}", "white")
+                (f" @ {bitrate_str}{fps_str}", "white")
             )
             current_branch.add(label)
-        
-        console.print(v_tree)
-        
-        v_idx = int(Prompt.ask("\n  Select Video Index", default="1")) - 1
-        v_sel = display_v[v_idx]
-        
-        is_single_output = not is_multi_input or selections["latest_episode"]
-        
-        # Calculate dl.py-compatible quality resolution height mapping
-        magic_quality = int(v_sel.width * 9 / 16)
-        
-        selections["vcodec"] = [v_sel.codec]
-        selections["range_"] = [v_sel.range]
-        selections["quality"] = [magic_quality]
 
-        if is_single_output:
-            selections["v_mode"] = "exact"
-            selections["vbitrate"] = BitrateMatcher(v_sel.bitrate, tolerance=0.05)
+        if not display_v:
+            tui_body("[yellow]No video tracks available after filtering; skipping video selection.[/]")
         else:
-            # Determine profile position for batch mode stability
-            profile_tracks = sorted(
-                [
-                    v for v in display_v 
-                    if v.height == v_sel.height and v.width == v_sel.width 
-                    and v.codec == v_sel.codec and v.range == v_sel.range
-                ], 
-                key=lambda x: x.bitrate, 
-                reverse=True
-            )
-            
-            selections["vbitrate"] = None  # Prevent strict bitrate matching in batch mode
-            if v_sel.bitrate == profile_tracks[0].bitrate:
-                selections["v_mode"] = "best"
-            else:
-                selections["v_mode"] = "worst"
+            tui_body(v_tree)
 
-        # Phase 5: Audio filtering
-        console.print(Padding(Rule("[rule.text]Phase 5: Audio Filters"), (1, 2, 1, 2)))
-        from unshackle.core.tracks import Audio
-        
+            v_choices = [str(i) for i in range(1, len(display_v) + 1)]
+            v_idx = int(tui_prompt(
+                "\nSelect Video Index", choices=v_choices, default="1", show_choices=False
+            )) - 1
+            v_sel = display_v[v_idx]
+
+            is_single_output = not is_multi_input or selections["latest_episode"]
+
+            # Map the selected track's real height to a dl.py quality tier
+            selections["vcodec"] = [v_sel.codec]
+            selections["range_"] = [v_sel.range]
+            if v_sel.height:
+                selections["quality"] = [get_standard_quality_tier(v_sel)]
+
+            if is_single_output:
+                selections["v_mode"] = "exact"
+                if v_sel.bitrate:
+                    selections["vbitrate"] = BitrateMatcher(v_sel.bitrate, tolerance=0.05)
+            else:
+                # Determine profile position for batch mode stability
+                profile_tracks = sorted(
+                    [
+                        v for v in display_v
+                        if v.height == v_sel.height and v.width == v_sel.width
+                        and v.codec == v_sel.codec and v.range == v_sel.range
+                    ],
+                    key=lambda x: x.bitrate or 0,
+                    reverse=True
+                )
+
+                selections["vbitrate"] = None  # Prevent strict bitrate matching in batch mode
+                if profile_tracks and (v_sel.bitrate or 0) == (profile_tracks[0].bitrate or 0):
+                    selections["v_mode"] = "best"
+                else:
+                    selections["v_mode"] = "worst"
+
+        tui_header("Phase 5: Audio Filters")
+
         a_pool = target.tracks.audio
-        
-        # Filter out descriptive tracks early if not explicitly requested
+
+        # Drop descriptive tracks unless requested.
         if not selections.get("audio_description"):
             a_pool = [a for a in a_pool if not getattr(a, 'descriptive', False)]
 
-        # Filter by audio codec
         a_codecs = list(Audio.Codec)
-        a_codec_options = [f"[bold white]  1. Any / Default [/] [[bold white]{len(a_pool):>3}[/]]"]
-        
+        a_codec_options = [f"[bold white] 1. Any / Default [/] [[bold white]{len(a_pool):>3}[/]]"]
+
         for idx, c in enumerate(a_codecs, 2):
             count = len([a for a in a_pool if a.codec == c])
             style = "white" if count > 0 else "dim"
             label = f"{c.name} ({c.value})"
-            a_codec_options.append(f"[{style}] {idx:2}. {label:<14}[/] [[bold]{count:>3}[/]]")
-            
-        ac_table = Table(show_header=False, box=None, padding=(0, 1))
+            a_codec_options.append(f"[{style}]{idx:2}. {label:<14}[/] [[bold]{count:>3}[/]]")
+
+        ac_table = Table(show_header=False, box=None, pad_edge=False, padding=(0, 1))
         for _ in range(2):
             ac_table.add_column()
 
@@ -530,20 +543,19 @@ def run_interactive_session(service: Any, titles: Any, log: Any, current_params:
                 else:
                     row_cells.append("")
             ac_table.add_row(*row_cells)
-            
-        console.print(" [bold green]Select Audio Codec Filter:[/]")
-        console.print(ac_table)
-        
-        af_idx_str = Prompt.ask("\n  Select Audio Codec Index", choices=[str(i) for i in range(1, len(a_codec_options) + 1)], default="1", show_choices=False)
+
+        tui_body("[bold green]Select Audio Codec Filter:[/]")
+        tui_body(ac_table)
+
+        af_idx_str = tui_prompt("\nSelect Audio Codec Index", choices=[str(i) for i in range(1, len(a_codec_options) + 1)], default="1", show_choices=False)
         if af_idx_str != "1":
             selected_a_codec = a_codecs[int(af_idx_str) - 2]
             selections["acodec"] = [selected_a_codec]
             a_pool = [a for a in a_pool if a.codec == selected_a_codec]
 
-        # Phase 5.5: Audio track selection
         if a_pool:
             display_a = a_pool
-            
+
             # Sort by: Original language first -> Language alphabetical -> Channels -> Bitrate
             display_a = sorted(display_a, key=lambda x: (
                 not getattr(x, 'is_original_lang', False),
@@ -551,14 +563,14 @@ def run_interactive_session(service: Any, titles: Any, log: Any, current_params:
                 float(x.channels or 0),
                 x.bitrate or 0
             ))
-            
+
             a_tree = Tree("\n[bold green]Available Audio Tracks:[/]", guide_style="dim")
             last_lang = None
             current_branch = a_tree
 
             for i, t in enumerate(display_a, 1):
                 lang_str = str(t.language).upper()
-                
+
                 if lang_str != last_lang:
                     is_orig = getattr(t, 'is_original_lang', False)
                     orig_tag = " [yellow](Original)[/]" if is_orig else ""
@@ -566,44 +578,44 @@ def run_interactive_session(service: Any, titles: Any, log: Any, current_params:
                     last_lang = lang_str
 
                 codec_label = t.codec.value if hasattr(t.codec, 'value') else str(t.codec).split('.')[-1]
-                
+
                 tags = []
-                if getattr(t, 'atmos', False): tags.append("Atmos")
-                if getattr(t, 'descriptive', False): tags.append("AD")
-                
-                # Safe channel count retrieval
+                if getattr(t, 'atmos', False):
+                    tags.append("Atmos")
+                if getattr(t, 'descriptive', False):
+                    tags.append("AD")
+
                 try:
                     channels_str = f"{float(t.channels):.1f}" if t.channels is not None else "2.0"
                 except (ValueError, TypeError):
                     channels_str = "2.0"
-                
+
                 parts = [
-                    (f" {i:3} - ", "white"), 
-                    ("[", "bold white"), 
-                    (f"{codec_label:<4}", "cyan"), 
+                    (f" {i:3} - ", "white"),
+                    ("[", "bold white"),
+                    (f"{codec_label:<4}", "cyan"),
                     ("]", "bold white"),
                     (f" {channels_str} ch | {t.bitrate//1000 if t.bitrate else 'VBR'}kbps", "white")
                 ]
                 if tags:
                     parts.append((f" ({', '.join(tags)})", "dim"))
-                
+
                 current_branch.add(Text.assemble(*parts))
-            
-            console.print(a_tree)
-            
-            # Handle track selection and prevent engine crashes from duplicates
-            a_input = Prompt.ask("\n  Select Audio indices (eg.: 2 6-9)", default="1")
+
+            tui_body(a_tree)
+
+            a_input = tui_prompt("\nSelect Audio indices (eg.: 2 6-9)", default="1")
             a_idxs = parse_indices(a_input, len(display_a))
-            
+
             selected_raw = [display_a[i] for i in a_idxs]
             unique_map = {}
             seen_combos = set()
-            
+
             for t in selected_raw:
                 # Deduplicate based on base language (e.g., prevent es-419 vs es-ES collisions)
                 lang_base = str(t.language).split('-')[0].split('_')[0].lower()
                 combo = (lang_base, t.bitrate)
-                
+
                 if combo not in seen_combos:
                     unique_map[combo] = t
                     seen_combos.add(combo)
@@ -618,10 +630,10 @@ def run_interactive_session(service: Any, titles: Any, log: Any, current_params:
             unique_tracks = list(unique_map.values())
             selections["a_lang"] = [str(t.language) for t in unique_tracks]
             selections["acodec"] = list(set(t.codec for t in unique_tracks))
-            
+
             if any(getattr(t, 'descriptive', False) for t in unique_tracks):
                 selections["audio_description"] = True
-            
+
             a_bitrates = [t.bitrate for t in unique_tracks if getattr(t, 'bitrate', None)]
             if a_bitrates:
                 selections["abitrate"] = BitrateMatcher(list(set(a_bitrates)))
@@ -629,23 +641,25 @@ def run_interactive_session(service: Any, titles: Any, log: Any, current_params:
         # Phase 6: Subtitles
         if not selections["skip_dl"] and target.tracks.subtitles:
             display_s = sorted(target.tracks.subtitles, key=lambda x: str(x.language))
-            
-            console.print(Padding(Rule("[rule.text]Phase 6: Available Subtitle Tracks"), (1, 2, 1, 2)))
-            
-            s_table = Table(show_header=False, box=None, padding=(0, 2))
+
+            tui_header("Phase 6: Available Subtitle Tracks")
+
+            s_table = Table(show_header=False, box=None, pad_edge=False, padding=(0, 2))
             for _ in range(3):
                 s_table.add_column(no_wrap=True)
-            
+
             items = []
             for i, t in enumerate(display_s, 1):
                 tags = []
-                if getattr(t, 'forced', False): tags.append("Forced")
-                if getattr(t, 'sdh', False) or getattr(t, 'cc', False): tags.append("SDH")
-                
+                if getattr(t, 'forced', False):
+                    tags.append("Forced")
+                if getattr(t, 'sdh', False) or getattr(t, 'cc', False):
+                    tags.append("SDH")
+
                 tag_str = ""
                 if tags:
                     tag_str = f" [dim]({', '.join(tags)})[/]"
-                items.append(f"  {i:2} - {t.language}{tag_str}")
+                items.append(f"{i:2} - {t.language}{tag_str}")
 
             s_rows = math.ceil(len(items) / 3)
             for r in range(s_rows):
@@ -657,10 +671,10 @@ def run_interactive_session(service: Any, titles: Any, log: Any, current_params:
                     else:
                         row_cells.append("")
                 s_table.add_row(*row_cells)
-            
-            console.print(s_table)
-            
-            s_input = Prompt.ask("\n  Select Subtitle indices (eg.: 2 6-9 or ENTER for none)", default="")
+
+            tui_body(s_table)
+
+            s_input = tui_prompt("\nSelect Subtitle indices (eg.: 2 6-9 or ENTER for none)", default="")
             if s_input:
                 s_idxs = parse_indices(s_input, len(display_s))
                 for i in s_idxs:
@@ -668,18 +682,17 @@ def run_interactive_session(service: Any, titles: Any, log: Any, current_params:
                         selections["forced_subs"] = True
                 selections["s_lang"] = list(set(str(display_s[i].language) for i in s_idxs))
 
-        # Prepare selections for engine delivery
         selections["v_lang"] = ["all"]
         if not selections["a_lang"]:
             selections["a_lang"] = ["all"]
-            
+
         selections["no_subs"] = not bool(selections["s_lang"])
-        
+
         if selections.get("latest_episode", False):
             selections["select_titles"] = False
 
         return selections
 
-    except Exception as e:
+    except Exception:
         console.print_exception()
-        sys.exit(1)
+        raise click.Abort()

--- a/unshackle/core/utils/selector.py
+++ b/unshackle/core/utils/selector.py
@@ -1,9 +1,12 @@
 import sys
+from typing import Any
 
 import click
 from rich.console import Group
 from rich.live import Live
-from rich.padding import Padding
+from rich.padding import Padding, PaddingDimensions
+from rich.prompt import Confirm, Prompt
+from rich.rule import Rule
 from rich.table import Table
 from rich.text import Text
 
@@ -12,6 +15,31 @@ from unshackle.core.console import console
 IS_WINDOWS = sys.platform == "win32"
 if IS_WINDOWS:
     import msvcrt
+
+CONTENT_INDENT = 5
+RULE_PAD = (1, 2)
+
+
+def tui_header(text: str, pad: PaddingDimensions = RULE_PAD) -> None:
+    console.print(Padding(Rule(f"[rule.text]{text}"), pad))
+
+
+def tui_body(renderable: Any, pad: PaddingDimensions = (0, CONTENT_INDENT)) -> None:
+    console.print(Padding(renderable, pad))
+
+
+def _indent(label: str) -> str:
+    body = label.lstrip("\n")
+    leading = "\n" * (len(label) - len(body))
+    return leading + (" " * CONTENT_INDENT) + body
+
+
+def tui_prompt(label: str, **kwargs: Any) -> str:
+    return Prompt.ask(_indent(label), **kwargs)
+
+
+def tui_confirm(label: str, **kwargs: Any) -> bool:
+    return Confirm.ask(_indent(label), **kwargs)
 
 
 class Selector:
@@ -29,6 +57,7 @@ class Selector:
         minimal_count: int = 0,
         dependencies: dict[int, list[int]] = None,
         collapse_on_start: bool = False,
+        single_select: bool = False,
     ):
         """
         Initialize the Selector.
@@ -47,6 +76,7 @@ class Selector:
         self.text_style = text_style
         self.page_size = page_size
         self.minimal_count = minimal_count
+        self.single_select = single_select
         self.dependencies = dependencies or {}
 
         # Parent-Child mapping for quick lookup
@@ -121,7 +151,10 @@ class Selector:
             is_cursor = idx == self.cursor_index
             is_selected = idx in self.selected_indices
 
-            symbol = "[X]" if is_selected else "[ ]"
+            if self.single_select:
+                symbol = "❯" if is_cursor else " "
+            else:
+                symbol = "[X]" if is_selected else "[ ]"
             style = self.cursor_style if is_cursor else self.text_style
             indicator_text = Text(f"{symbol}", style=style)
 
@@ -141,7 +174,12 @@ class Selector:
             total_pages = 1
         current_page = (self.scroll_offset // self.page_size) + 1
 
-        if self.dependencies:
+        if self.single_select:
+            info_text = Text(
+                f"\n[↑/↓]: Move  [←/→]: Page  [Enter]: Select  (Page {current_page}/{total_pages})",
+                style="gray",
+            )
+        elif self.dependencies:
             info_text = Text(
                 f"\n[Space]: Toggle  [a]: All  [e]: Fold/Unfold  [E]: All Fold/Unfold\n[Enter]: Confirm  [↑/↓]: Move  [←/→]: Page  (Page {current_page}/{total_pages})",
                 style="gray",
@@ -152,7 +190,7 @@ class Selector:
                 style="gray",
             )
 
-        return Padding(Group(table, info_text), (0, 5))
+        return Padding(Group(table, info_text), (0, CONTENT_INDENT))
 
     def move_cursor(self, delta: int):
         """
@@ -390,10 +428,15 @@ class Selector:
                     elif action == "EXPAND_ALL":
                         self.toggle_expand_all()
                     elif action == "SPACE":
+                        if self.single_select:
+                            return [self.cursor_index]
                         self.toggle_selection()
                     elif action == "ALL":
-                        self.toggle_all()
+                        if not self.single_select:
+                            self.toggle_all()
                     elif action in ("ENTER", "QUIT"):
+                        if self.single_select:
+                            return [self.cursor_index]
                         if len(self.selected_indices) >= self.minimal_count:
                             return sorted(list(self.selected_indices))
                     elif action == "CANCEL":


### PR DESCRIPTION
Interactive TUI to use precise index-based selection (numbered lists and index parsing) for service, option, and track configuration.

- **Index-Based Selection:** Replaced raw text input prompts with numbered index selectors across all selection phases (services, video/audio codecs, video ranges, and tracks).
- **Service-Specific Options:** If enabled,  Dynamically loads and prompts for extra Click options defined in individual service files if they are not already managed globally.
- **Reference Title Selection:** Prompts for a reference episode index when downloading multiple series titles, using its track layout as a template to avoid repetitive prompting.
- **User Configuration Support:** Supports pre-checking Phase 1 options via the user's YAML configuration file under the `interactive` key, while still allowing them to be toggled all others during the TUI session.
example:
 ```
 interactive:
  no_mux: false
  export: true
 ```
- **Index Parsing (`parse_indices`):** Added support for comma-separated lists, ranges, and reversed ranges (e.g., `3-1`) when selecting multiple audio or subtitle tracks.
- **Option Normalization:** Normalizes interactive choices back to the raw types expected by the service CLI commands (resolving enum values and list wrappers).
- **Audio Collision Protection:** Automatically filters duplicate language/bitrate tracks to prevent multiplexer crashes, prioritizing descriptive (AD) tracks when both are selected.
- **Batch Mode Bitrate Handling:** Bypasses strict bitrate matching (`v_mode="best"`, `vbitrate=None`) when downloading multiple series titles to ensure batch pipeline stability.
- **CLI Option Bypass:** Skips interactive prompts for any options already explicitly passed via CLI flags.