### PR TITLE
fix(dash): correct multi-period manifest handling (descriptive role + main period)

### DIFF
--- a/tests/core/test_dash_multiperiod.py
+++ b/tests/core/test_dash_multiperiod.py
@@ -1,0 +1,182 @@
+"""Multi-period DASH handling: descriptive-role detection and cross-period matching.
+
+Two fixes for multi-period manifests (e.g. short ad/bumper periods around the main
+content) are locked down here:
+
+- ``is_descriptive`` must recognise an audio-description set marked with the standard
+  ``<Role value="description">``. Services do not always use the ``Accessibility``
+  descriptor; without this, a description set is indistinguishable from the regular
+  audio of the same language and bitrate and both hash to the same track id.
+- ``_match_representation_in_period`` must find the wanted track in every content
+  period. Services often reuse a different Representation id per period, so matching
+  on id alone truncates the download to the track's origin period.
+"""
+
+from __future__ import annotations
+
+from lxml import etree
+
+from unshackle.core.manifests.dash import DASH
+
+
+def _el(xml: str):
+    return etree.fromstring(xml)
+
+
+def _period(pid: str, *, en=(70000, 137000), end=(137000,), he=(70000, 137000)) -> etree._Element:
+    """Build a Period whose Representation ids are namespaced by ``pid`` so they
+    differ from those in other periods, mirroring real multi-period manifests."""
+    en_reps = "".join(f'<Representation id="{pid}_en_{b}" bandwidth="{b}" codecs="mp4a.40.2"/>' for b in en)
+    end_reps = "".join(f'<Representation id="{pid}_end_{b}" bandwidth="{b}" codecs="mp4a.40.2"/>' for b in end)
+    he_reps = "".join(f'<Representation id="{pid}_he_{b}" bandwidth="{b}" codecs="mp4a.40.2"/>' for b in he)
+    return _el(
+        f'<Period id="{pid}">'
+        f'<AdaptationSet contentType="audio" lang="en">{en_reps}</AdaptationSet>'
+        f'<AdaptationSet contentType="audio" lang="en">'
+        f'<Role schemeIdUri="urn:mpeg:dash:role:2011" value="description"/>{end_reps}</AdaptationSet>'
+        f'<AdaptationSet contentType="audio" lang="he">{he_reps}</AdaptationSet>'
+        f'<AdaptationSet contentType="video" lang="en">'
+        f'<Representation id="{pid}_v" bandwidth="2000000" codecs="avc1.640028"/></AdaptationSet>'
+        f"</Period>"
+    )
+
+
+def _find(period, rep_id):
+    """Return (adaptation_set, representation) for a Representation id in a period."""
+    for as_ in period.findall("AdaptationSet"):
+        for rep in as_.findall("Representation"):
+            if rep.get("id") == rep_id:
+                return as_, rep
+    raise AssertionError(f"{rep_id} not in period")
+
+
+class TestIsDescriptive:
+    def test_role_description(self):
+        as_ = _el(
+            '<AdaptationSet lang="en"><Role schemeIdUri="urn:mpeg:dash:role:2011" value="description"/></AdaptationSet>'
+        )
+        assert DASH.is_descriptive(as_) is True
+
+    def test_role_descriptive(self):
+        as_ = _el(
+            '<AdaptationSet lang="en"><Role schemeIdUri="urn:mpeg:dash:role:2011" value="descriptive"/></AdaptationSet>'
+        )
+        assert DASH.is_descriptive(as_) is True
+
+    def test_accessibility_still_detected(self):
+        as_ = _el(
+            '<AdaptationSet lang="en">'
+            '<Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value="1"/></AdaptationSet>'
+        )
+        assert DASH.is_descriptive(as_) is True
+
+    def test_plain_audio_not_descriptive(self):
+        as_ = _el('<AdaptationSet lang="en"><Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/></AdaptationSet>')
+        assert DASH.is_descriptive(as_) is False
+
+
+class TestMatchRepresentationInPeriod:
+    def test_exact_id_wins(self):
+        src = _period("p1")
+        as_, rep = _find(src, "p1_he_137000")
+        m_as, m_rep = DASH._match_representation_in_period(
+            src, rep_id="p1_he_137000", adaptation_set=as_, representation=rep
+        )
+        assert m_rep.get("id") == "p1_he_137000"
+
+    def test_cross_period_matches_language_and_closest_bitrate(self):
+        # Track originates in p1; the same logical track has different ids and
+        # slightly different bandwidths in p2.
+        src = _period("p1", he=(70000, 137000))
+        tgt = _period("p2", he=(57000, 136500))
+        as_, rep = _find(src, "p1_he_137000")
+        m_as, m_rep = DASH._match_representation_in_period(
+            tgt, rep_id="p1_he_137000", adaptation_set=as_, representation=rep
+        )
+        assert m_as.get("lang") == "he"
+        assert m_rep.get("id") == "p2_he_136500"  # closest rung, not the 57000 one
+
+    def test_descriptive_does_not_match_regular_audio(self):
+        # Origin is the English audio-description set; it must match only the
+        # description set in the target period, never the regular English audio.
+        src = _period("p1")
+        tgt = _period("p2")
+        as_, rep = _find(src, "p1_end_137000")
+        assert DASH.is_descriptive(as_) is True
+        m_as, m_rep = DASH._match_representation_in_period(
+            tgt, rep_id="p1_end_137000", adaptation_set=as_, representation=rep
+        )
+        assert DASH.is_descriptive(m_as) is True
+        assert m_rep.get("id") == "p2_end_137000"
+
+    def test_regular_audio_does_not_match_descriptive(self):
+        # Mirror: a regular English track must not be served the description set.
+        src = _period("p1")
+        tgt = _period("p2")
+        as_, rep = _find(src, "p1_en_137000")
+        assert DASH.is_descriptive(as_) is False
+        m_as, m_rep = DASH._match_representation_in_period(
+            tgt, rep_id="p1_en_137000", adaptation_set=as_, representation=rep
+        )
+        assert DASH.is_descriptive(m_as) is False
+        assert m_as.get("lang") == "en"
+        assert m_rep.get("id") == "p2_en_137000"
+
+    def test_no_match_returns_none(self):
+        src = _period("p1")
+        as_, rep = _find(src, "p1_he_137000")
+        video_only = _el(
+            '<Period id="p3"><AdaptationSet contentType="video" lang="en">'
+            '<Representation id="p3_v" bandwidth="2000000" codecs="avc1.640028"/></AdaptationSet></Period>'
+        )
+        m_as, m_rep = DASH._match_representation_in_period(
+            video_only, rep_id="p1_he_137000", adaptation_set=as_, representation=rep
+        )
+        assert (m_as, m_rep) == (None, None)
+
+    def test_video_matches_resolution_not_just_bitrate(self):
+        # Period bandwidths drift: the 1080p rung's bandwidth in p2 is *closer* to p1's 720p
+        # bandwidth than to p1's 1080p bandwidth. Matching on bandwidth alone would pull 720p;
+        # matching on height must keep 1080p.
+        src = _el(
+            '<Period id="p1"><AdaptationSet contentType="video" lang="en">'
+            '<Representation id="p1_v720" width="1280" height="720" bandwidth="1500000" codecs="avc1.4d401f"/>'
+            '<Representation id="p1_v1080" width="1920" height="1080" bandwidth="3900000" codecs="avc1.640028"/>'
+            "</AdaptationSet></Period>"
+        )
+        tgt = _el(
+            '<Period id="p2"><AdaptationSet contentType="video" lang="en">'
+            '<Representation id="p2_v720" width="1280" height="720" bandwidth="1400000" codecs="avc1.4d401f"/>'
+            '<Representation id="p2_v1080" width="1920" height="1080" bandwidth="1600000" codecs="avc1.640028"/>'
+            "</AdaptationSet></Period>"
+        )
+        as_, rep = _find(src, "p1_v1080")
+        m_as, m_rep = DASH._match_representation_in_period(
+            tgt, rep_id="p1_v1080", adaptation_set=as_, representation=rep
+        )
+        assert m_rep.get("height") == "1080"
+        assert m_rep.get("id") == "p2_v1080"
+
+
+class TestPeriodDurationSeconds:
+    def test_minutes_seconds(self):
+        assert DASH._period_duration_seconds(_el('<Period duration="PT21M42.000S"/>')) == 21 * 60 + 42
+
+    def test_hours_minutes_seconds(self):
+        assert DASH._period_duration_seconds(_el('<Period duration="PT1H2M3S"/>')) == 3723
+
+    def test_short_bumper(self):
+        assert DASH._period_duration_seconds(_el('<Period duration="PT2.990S"/>')) == 2.99
+
+    def test_missing_duration_is_zero(self):
+        assert DASH._period_duration_seconds(_el('<Period id="x"/>')) == 0.0
+
+    def test_longest_period_is_the_main_content(self):
+        # The main content period must win over short ident/bumper periods.
+        periods = [
+            _el('<Period id="seq:-1_0" duration="PT2.990S"/>'),
+            _el('<Period id="seq:0_0" duration="PT21M42.000S"/>'),
+            _el('<Period id="seq:1_0" duration="PT10.000S"/>'),
+        ]
+        main = max(periods, key=DASH._period_duration_seconds)
+        assert main.get("id") == "seq:0_0"

--- a/unshackle/core/manifests/dash.py
+++ b/unshackle/core/manifests/dash.py
@@ -355,21 +355,32 @@ class DASH:
 
         if period_count > 1:
             log.debug(f"Multi-period manifest detected with {period_count} content periods")
+            # Keep only the longest (main content) period. Services that wrap the main
+            # content in short ident/bumper periods give each period its own init segment;
+            # muxing one period's media under another period's init mis-times the output
+            # (video PTS stretch). Restricting to the single main period keeps init and
+            # media consistent and yields correct timing. It is also more correct than the
+            # prior behaviour, which matched the track by id and so could download whichever
+            # period the track happened to originate from (e.g. a 3s bumper) instead of the
+            # actual episode.
+            main_period = max(content_periods, key=DASH._period_duration_seconds)
+            log.debug(
+                f"Using main content period '{main_period.get('id')}' "
+                f"({DASH._period_duration_seconds(main_period):.0f}s)"
+            )
+            content_periods = [main_period]
+            period_count = 1
 
         for period_idx, content_period in enumerate(content_periods):
-            # Find the matching representation in this period
-            matched_rep = None
-            matched_as = None
-            for as_ in content_period.findall("AdaptationSet"):
-                if DASH.is_trick_mode(as_):
-                    continue
-                for rep in as_.findall("Representation"):
-                    if rep.get("id") == rep_id:
-                        matched_rep = rep
-                        matched_as = as_
-                        break
-                if matched_rep is not None:
-                    break
+            # Find the matching representation in this period. Match by id first, then
+            # by characteristics, so multi-period manifests that reuse a different
+            # Representation id per period are not truncated to the origin period.
+            matched_as, matched_rep = DASH._match_representation_in_period(
+                content_period,
+                rep_id=rep_id,
+                adaptation_set=adaptation_set,
+                representation=representation,
+            )
 
             if matched_rep is None or matched_as is None:
                 period_id = content_period.get("id", period_idx)
@@ -947,7 +958,107 @@ class DASH:
             (x.get("schemeIdUri"), x.get("value"))
             in (("urn:mpeg:dash:role:2011", "descriptive"), ("urn:tva:metadata:cs:AudioPurposeCS:2007", "1"))
             for x in adaptation_set.findall("Accessibility")
+        ) or any(
+            x.get("schemeIdUri") == "urn:mpeg:dash:role:2011" and x.get("value") in ("description", "descriptive")
+            for x in adaptation_set.findall("Role")
         )
+
+    @staticmethod
+    def _period_duration_seconds(period: Element) -> float:
+        """Parse an ISO 8601 Period@duration (e.g. ``PT21M42.000S``) into seconds."""
+        duration = period.get("duration") or ""
+        seconds = 0.0
+        for value, unit in re.findall(r"(\d+\.?\d*)([HMS])", duration):
+            seconds += float(value) * {"H": 3600, "M": 60, "S": 1}[unit]
+        return seconds
+
+    @staticmethod
+    def _match_representation_in_period(
+        period: Element,
+        *,
+        rep_id: Optional[str],
+        adaptation_set: Element,
+        representation: Element,
+    ) -> tuple[Optional[Element], Optional[Element]]:
+        """
+        Find the Representation in ``period`` that corresponds to a wanted track.
+
+        A service may give the same logical track a different Representation id in
+        each Period of a multi-period manifest, so matching on id alone finds the
+        track only in its origin Period and silently truncates the download to that
+        one Period. When the id is absent, fall back to matching by content type,
+        language, codec and descriptive role, then pick the rung with the closest
+        bandwidth (rungs are far enough apart that the nearest one is the right one
+        even when per-period bandwidths differ slightly).
+
+        Returns the matching (AdaptationSet, Representation), or (None, None).
+        """
+
+        def content_type(as_el: Element, rep_el: Optional[Element] = None) -> Optional[str]:
+            ct = (rep_el.get("contentType") if rep_el is not None else None) or as_el.get("contentType")
+            if not ct:
+                mime = (rep_el.get("mimeType") if rep_el is not None else None) or as_el.get("mimeType")
+                ct = mime.split("/")[0] if mime else None
+            return ct
+
+        # An exact Representation id match wins when the service keeps ids stable.
+        for as_el in period.findall("AdaptationSet"):
+            if DASH.is_trick_mode(as_el):
+                continue
+            for rep_el in as_el.findall("Representation"):
+                if rep_el.get("id") == rep_id:
+                    return as_el, rep_el
+
+        def height(rep_el: Element, as_el: Element) -> int:
+            for el in (rep_el, as_el):
+                try:
+                    h = int(el.get("height") or 0)
+                except ValueError:
+                    h = 0
+                if h:
+                    return h
+            return 0
+
+        want_ct = content_type(adaptation_set, representation)
+        want_lang = adaptation_set.get("lang") or representation.get("lang")
+        want_codecs = representation.get("codecs") or adaptation_set.get("codecs")
+        want_descriptive = DASH.is_descriptive(adaptation_set)
+        want_height = height(representation, adaptation_set)
+        try:
+            want_bandwidth = int(representation.get("bandwidth") or 0)
+        except ValueError:
+            want_bandwidth = 0
+
+        best: Optional[tuple[int, Element, Element]] = None
+        for as_el in period.findall("AdaptationSet"):
+            if DASH.is_trick_mode(as_el):
+                continue
+            if DASH.is_descriptive(as_el) != want_descriptive:
+                continue
+            as_lang = as_el.get("lang")
+            for rep_el in as_el.findall("Representation"):
+                if want_ct and content_type(as_el, rep_el) not in (None, want_ct):
+                    continue
+                if want_lang and (rep_el.get("lang") or as_lang) not in (None, want_lang):
+                    continue
+                rep_codecs = rep_el.get("codecs") or as_el.get("codecs")
+                if want_codecs and rep_codecs and rep_codecs != want_codecs:
+                    continue
+                # For video the resolution must match: bandwidths drift between periods, so a
+                # closest-bandwidth match alone can land on the wrong rung (pull 720p when 1080p
+                # was wanted). Height is stable across periods.
+                if want_height and height(rep_el, as_el) != want_height:
+                    continue
+                try:
+                    bw = int(rep_el.get("bandwidth") or 0)
+                except ValueError:
+                    bw = 0
+                score = abs(bw - want_bandwidth)
+                if best is None or score < best[0]:
+                    best = (score, as_el, rep_el)
+        if best is not None:
+            return best[1], best[2]
+        return None, None
 
     @staticmethod
     def is_forced(adaptation_set: Element) -> bool:


### PR DESCRIPTION
Multi-period DASH manifests where a service wraps the main content in short ident/bumper periods (Disney+ Hotstar: a 3s intro, the ~21:42 episode, a 10s outro) were mishandled in two ways. Verified end-to-end against such a title.

### What's here

- **Descriptive audio detected by `Role`, not only `Accessibility`.** `is_descriptive` only matched the `Accessibility` descriptor, so an audio-description set marked with the standard `<Role value="description">` was not flagged. It then looked identical to the regular audio of the same language and bitrate, both hashed to the **same track id**, and `to_tracks` raised the duplicate-track error before anything could download. The descriptive `Role` is now matched too.

- **Download the main content period, resolving the track within it by characteristics.** The download matched the wanted Representation in each period by exact `id`. Services reuse a *different* Representation id per period, so the match succeeded only in the track's origin period, and the muxed output was whatever period the track happened to originate from. For Hotstar that origin is the **3s intro bumper**, so a full episode came out as ~3 seconds.

  Concatenating all periods is not the fix either: each period carries its own init segment, and muxing one period's media under another period's init **stretches the video PTS** (frames correct, timestamps run ~5x long). Instead, this selects the single longest (main content) period and resolves the wanted track within it: exact `id` first, then a fallback match by content type, language, codec, descriptive role and **resolution** (height), choosing the closest-bandwidth rung. Matching height matters because bandwidths drift between periods, so a closest-bandwidth match alone can pull the wrong rung (720p when 1080p was wanted). Init and media then come from one period and timing is correct.

### Verified

A title that previously produced a ~3s file now produces the full ~21:42 episode at the correct 25 fps, video and audio in sync, at the requested resolution.

### Tests

`tests/core/test_dash_multiperiod.py`: descriptive-role detection, cross-characteristic representation matching (language + closest-bitrate, descriptive vs regular disambiguation, video resolution preserved when bandwidths drift, no-match case), and ISO-8601 period-duration parsing / main-period selection.