### PR TITLE
fix(widevine): fall back to mp4decrypt when Shaka Packager errors

### DIFF
--- a/tests/core/test_widevine_decrypt.py
+++ b/tests/core/test_widevine_decrypt.py
@@ -1,0 +1,117 @@
+"""Decrypter-selection tests for ``Widevine.decrypt``.
+
+These lock down the routing between the two decryption backends:
+
+- ``config.decryption == "mp4decrypt"`` forces the Bento4 path.
+- Otherwise Shaka Packager is the default.
+- If Shaka fails (e.g. older builds SIGSEGV on Smooth/PIFF content), decrypt
+  must fall back to mp4decrypt rather than failing the whole download.
+- The fallback only applies when mp4decrypt is actually available; with no
+  fallback binary the original Shaka error must propagate (no silent swallow).
+
+The two ``_decrypt_with_*`` workers are stubbed so the tests exercise the
+routing logic without invoking real binaries.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+from pywidevine.pssh import PSSH
+
+from unshackle.core import binaries
+from unshackle.core.config import config
+from unshackle.core.drm.widevine import Widevine
+
+KID = "2fa4d930623a401585ab00dfca7b4b29"
+KEY = "6b0cce75fa87bb9ba36308f0c4d8a861"
+
+
+def make_widevine() -> Widevine:
+    wv = Widevine(pssh=PSSH.new(system_id=PSSH.SystemId.Widevine, key_ids=[KID]), kid=KID)
+    # decrypt() refuses to run without content keys; the value is never read by the stubs.
+    wv.content_keys = {kid: KEY for kid in wv.kids}
+    return wv
+
+
+@pytest.fixture
+def enc_file(tmp_path):
+    path = tmp_path / "track.mp4"
+    path.write_bytes(b"\x00encrypted\x00")
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _reset_decryption():
+    """decrypt() reads the shared config singleton; keep tests isolated from each other."""
+    original = getattr(config, "decryption", None)
+    yield
+    config.decryption = original
+
+
+def _record(wv, calls, *, shaka_exc=None):
+    """Stub both backends to record invocation order; optionally make Shaka raise."""
+
+    def shaka(path):
+        calls.append("shaka")
+        if shaka_exc is not None:
+            raise shaka_exc
+
+    def mp4decrypt(path):
+        calls.append("mp4decrypt")
+
+    wv._decrypt_with_shaka_packager = shaka
+    wv._decrypt_with_mp4decrypt = mp4decrypt
+
+
+def test_explicit_mp4decrypt_skips_shaka(enc_file):
+    config.decryption = "mp4decrypt"
+    wv = make_widevine()
+    calls = []
+    _record(wv, calls)
+    wv.decrypt(enc_file)
+    assert calls == ["mp4decrypt"]
+
+
+def test_default_uses_shaka_without_fallback(enc_file):
+    config.decryption = ""
+    wv = make_widevine()
+    calls = []
+    _record(wv, calls)  # shaka succeeds
+    wv.decrypt(enc_file)
+    assert calls == ["shaka"]
+
+
+def test_shaka_failure_falls_back_to_mp4decrypt(enc_file, monkeypatch):
+    config.decryption = ""
+    monkeypatch.setattr(binaries, "Mp4decrypt", "/usr/bin/mp4decrypt")
+    wv = make_widevine()
+    calls = []
+    _record(wv, calls, shaka_exc=subprocess.CalledProcessError(-11, ["packager"]))
+    wv.decrypt(enc_file)
+    assert calls == ["shaka", "mp4decrypt"]
+
+
+def test_shaka_failure_clears_stale_partial_output(enc_file, monkeypatch):
+    config.decryption = ""
+    monkeypatch.setattr(binaries, "Mp4decrypt", "/usr/bin/mp4decrypt")
+    stale = enc_file.with_stem(f"{enc_file.stem}_decrypted")
+    stale.write_bytes(b"partial shaka output")
+    wv = make_widevine()
+    calls = []
+    _record(wv, calls, shaka_exc=subprocess.CalledProcessError(-11, ["packager"]))
+    wv.decrypt(enc_file)
+    assert calls == ["shaka", "mp4decrypt"]
+    assert not stale.exists()  # cleared so mp4decrypt starts clean
+
+
+def test_shaka_failure_reraises_without_mp4decrypt(enc_file, monkeypatch):
+    config.decryption = ""
+    monkeypatch.setattr(binaries, "Mp4decrypt", None)
+    wv = make_widevine()
+    calls = []
+    _record(wv, calls, shaka_exc=subprocess.CalledProcessError(-11, ["packager"]))
+    with pytest.raises(subprocess.CalledProcessError):
+        wv.decrypt(enc_file)
+    assert calls == ["shaka"]  # no fallback attempted

--- a/unshackle/core/drm/widevine.py
+++ b/unshackle/core/drm/widevine.py
@@ -333,7 +333,27 @@ class Widevine:
         if decrypter == "mp4decrypt":
             self._decrypt_with_mp4decrypt(path)
         else:
-            self._decrypt_with_shaka_packager(path)
+            # Default to Shaka Packager, falling back to mp4decrypt on failure. Some Shaka
+            # builds error (e.g. SIGSEGV) on Smooth/PIFF-origin content; mp4decrypt reads the
+            # same content keys, so fall back to it rather than failing the whole download.
+            try:
+                self._decrypt_with_shaka_packager(path)
+            except subprocess.CalledProcessError as e:
+                if not binaries.Mp4decrypt:
+                    raise
+                # Shaka may have left a partial *_decrypted file; clear it so mp4decrypt starts clean.
+                stale = path.with_stem(f"{path.stem}_decrypted")
+                if stale.exists():
+                    stale.unlink()
+                log_event(
+                    "drm_decrypt_fallback",
+                    level="WARNING",
+                    message=f"Shaka Packager failed (exit {e.returncode}); falling back to mp4decrypt",
+                    drm_type="Widevine",
+                    tool="mp4decrypt",
+                    file=path.name,
+                )
+                self._decrypt_with_mp4decrypt(path)
 
         log_event(
             "drm_decrypt_complete",


### PR DESCRIPTION
### What's here

Shaka Packager is the default Widevine decrypter, but some builds error (e.g. SIGSEGV) on Smooth/PIFF-origin content, which currently fails the whole download even though Bento4's mp4decrypt handles the same file with the same content keys.

`Widevine.decrypt` now falls back to mp4decrypt when Shaka raises:

- Fallback triggers only on a `CalledProcessError` from Shaka **and** only when `binaries.Mp4decrypt` is available. With no fallback binary the original Shaka error propagates unchanged (no silent swallow).
- Shaka may leave a partial `*_decrypted` file behind; it is removed before mp4decrypt runs so it starts clean.
- The explicit `decryption: mp4decrypt` config path is unchanged.

### Tests

`tests/core/test_widevine_decrypt.py` stubs the two `_decrypt_with_*` workers and asserts the routing: explicit mp4decrypt skips Shaka, default uses Shaka with no fallback on success, Shaka failure falls back to mp4decrypt, the stale partial output is cleared before fallback, and the error re-raises when mp4decrypt is absent.