### PR TITLE
Feat/tag overrides

### DIFF
--- a/docs/OUTPUT_CONFIG.md
+++ b/docs/OUTPUT_CONFIG.md
@@ -233,6 +233,80 @@ language_tags:
 
 ---
 
+## tag_overrides (dict)
+
+Conditionally swaps the group `tag` (the `-{tag}` suffix produced by [`tag`](#tag-str))
+for a different value when a release matches a set of conditions. Useful when a subset of
+your releases should carry a different group name — for example tagging Russian-only
+releases, a specific service, or a given dynamic range with their own tag.
+
+Rules are evaluated in order; the first matching rule wins and its `tag` replaces the
+default group tag. All conditions within a single rule must match (AND logic). If no
+rule matches, the default `tag` is kept.
+
+Rules are evaluated against the **already-computed filename context**, so any value used
+in your `output_template` can be a condition.
+
+### Conditions
+
+| Condition | Type | Description |
+|-----------|------|-------------|
+| `lang_tag` | string / list | Matches the computed [`language_tags`](#language_tags-dict) value (e.g. `RUSSiAN`) |
+| `source` | string / list | Matches the service tag (e.g. `AMZN`) |
+| `hdr` | string / list | Matches the dynamic range tag (e.g. `DV`, `HDR10`, `HLG`) |
+| `video` | string / list | Matches the video codec tag (e.g. `H.265`) |
+| `quality` | string / list | Matches the quality tag (e.g. `2160p`) |
+| `resolution` | string / list | Matches the exact resolution (e.g. `1080`) |
+| `resolution_min` | int | Matches when resolution is at least this value |
+| `resolution_max` | int | Matches when resolution is at most this value |
+| `audio` | string / list | Matches the audio codec tag (e.g. `EAC3`) |
+| `atmos`, `dual`, `multi`, `edition`, `repack`, `hfr`, `audio_channels` | string / list | Match the corresponding context value |
+| `audio_lang` | string | Matches if any selected audio track has this language (fuzzy) |
+| `subs_lang` | string | Matches if any selected subtitle has this language (fuzzy) |
+| `audio_count_min` | int | Matches when there are at least this many distinct audio languages |
+
+String conditions are matched case-insensitively; a list matches if **any** entry matches.
+Language conditions (`audio_lang`, `subs_lang`) use fuzzy matching (e.g. `en` matches `en-US`).
+
+### Example: per-language group tag
+
+```yaml
+tag: "NOGRP"
+
+language_tags:
+  rules:
+    - audio: ru
+      tag: RUSSiAN
+
+tag_overrides:
+  rules:
+    # Russian-only releases ship under a different group name
+    - lang_tag: RUSSiAN
+      tag: RUGROUP
+```
+
+Example outputs:
+
+- Russian audio: `Example.Show.S01E01.RUSSiAN.1080p.EXAMPLE.WEB-DL.DDP5.1.H.264-RUGROUP`
+- Anything else: `Example.Show.S01E01.1080p.EXAMPLE.WEB-DL.DDP5.1.H.264-NOGRP`
+
+### Example: combining conditions
+
+```yaml
+tag_overrides:
+  rules:
+    # 4K Dolby Vision pulls from a dedicated tag
+    - resolution_min: 2160
+      hdr: DV
+      tag: UHDGROUP
+    # Amazon releases with Russian audio
+    - source: AMZN
+      audio_lang: ru
+      tag: RUAMZN
+```
+
+---
+
 ## unicode_filenames (bool)
 
 Allow Unicode characters in output filenames. When `false`, Unicode characters are transliterated

--- a/docs/OUTPUT_CONFIG.md
+++ b/docs/OUTPUT_CONFIG.md
@@ -251,6 +251,7 @@ in your `output_template` can be a condition.
 
 | Condition | Type | Description |
 |-----------|------|-------------|
+| `title_type` | string / list | Matches the media type: `movie`, `series`, or `music` (aliases: `film`, `episode`, `show`, `song`, `album`…) |
 | `lang_tag` | string / list | Matches the computed [`language_tags`](#language_tags-dict) value (e.g. `RUSSiAN`) |
 | `source` | string / list | Matches the service tag (e.g. `AMZN`) |
 | `hdr` | string / list | Matches the dynamic range tag (e.g. `DV`, `HDR10`, `HLG`) |
@@ -304,6 +305,25 @@ tag_overrides:
       audio_lang: ru
       tag: RUAMZN
 ```
+
+### Example: per media type
+
+```yaml
+tag_overrides:
+  rules:
+    # Russian-only movies first (most specific)
+    - title_type: movie
+      lang_tag: RUSSiAN
+      tag: RUMOVIES
+    # Then the broad per-type tags
+    - title_type: movie
+      tag: MOVGROUP
+    - title_type: series
+      tag: TVGROUP
+```
+
+> Order matters: place more specific rules (e.g. `title_type` + `lang_tag`) **before**
+> broader ones, since the first matching rule wins.
 
 ---
 

--- a/unshackle/core/config.py
+++ b/unshackle/core/config.py
@@ -117,6 +117,9 @@ class Config:
         self.redact_paths: bool = kwargs.get("redact_paths", True)
 
         self.language_tags: dict = kwargs.get("language_tags") or {}
+        # Conditionally swap the group tag (the `-{tag}` suffix) based on rules
+        # (e.g. RUSSiAN releases use a different group name). See tag_overrides docs.
+        self.tag_overrides: dict = kwargs.get("tag_overrides") or {}
         self.output_template: dict = kwargs.get("output_template") or {}
         folder_cfg = self.output_template.pop("folder", "")
         self.folder_template: str = ""

--- a/unshackle/core/titles/title.py
+++ b/unshackle/core/titles/title.py
@@ -78,7 +78,13 @@ class Title:
             primary_audio_track = next(iter(media_info.audio_tracks), None)
         unique_audio_languages = len({x.language.split("-")[0] for x in media_info.audio_tracks if x.language})
 
+        # Canonical title type (movie / series / music) for rule matching.
+        title_type = {"Movie": "movie", "Episode": "series", "Song": "music"}.get(
+            type(self).__name__, type(self).__name__.lower()
+        )
+
         context: dict[str, Any] = {
+            "title_type": title_type,
             "source": self.service.__name__ if show_service else "",
             "tag": config.tag or "",
             "repack": "REPACK" if getattr(config, "repack", False) else "",

--- a/unshackle/core/titles/title.py
+++ b/unshackle/core/titles/title.py
@@ -201,6 +201,16 @@ class Title:
             sub_langs = [s.language for s in self.tracks.subtitles]
             context["lang_tag"] = evaluate_language_tag(lang_tag_rules, audio_langs, sub_langs)
 
+        tag_override_rules = config.tag_overrides.get("rules") if config.tag_overrides else None
+        if tag_override_rules and self.tracks:
+            from unshackle.core.utils.tag_overrides import evaluate_tag_override
+
+            audio_langs = [a.language for a in self.tracks.audio]
+            sub_langs = [s.language for s in self.tracks.subtitles]
+            override = evaluate_tag_override(tag_override_rules, context, audio_langs, sub_langs)
+            if override:
+                context["tag"] = override
+
         return context
 
     @abstractmethod

--- a/unshackle/core/utils/tag_overrides.py
+++ b/unshackle/core/utils/tag_overrides.py
@@ -22,6 +22,25 @@ from unshackle.core.utilities import is_close_match
 
 log = logging.getLogger(__name__)
 
+# Friendly aliases for the ``title_type`` condition, mapped to the canonical
+# value stored in the context (movie / series / music).
+_TITLE_TYPE_ALIASES = {
+    "movie": "movie",
+    "movies": "movie",
+    "film": "movie",
+    "series": "series",
+    "serie": "series",
+    "episode": "series",
+    "episodes": "series",
+    "show": "series",
+    "tv": "series",
+    "song": "music",
+    "songs": "music",
+    "music": "music",
+    "album": "music",
+    "track": "music",
+}
+
 # Context fields a rule may match directly. Values are compared
 # case-insensitively; a list value matches if ANY entry matches.
 _STRING_FIELDS = (
@@ -85,6 +104,12 @@ def _string_matches(expected: Any, actual: Any) -> bool:
     return any(str(item).lower() == actual_norm for item in _as_list(expected))
 
 
+def _canon_title_type(value: Any) -> str:
+    """Normalise a title-type value through its aliases (e.g. film -> movie)."""
+    norm = str(value or "").lower()
+    return _TITLE_TYPE_ALIASES.get(norm, norm)
+
+
 def _rule_matches(
     rule: dict[str, Any],
     context: dict[str, Any],
@@ -93,6 +118,13 @@ def _rule_matches(
 ) -> bool:
     """Check if all conditions in a rule are satisfied (AND logic)."""
     has_condition = False
+
+    expected_type = rule.get("title_type")
+    if expected_type is not None:
+        has_condition = True
+        actual_type = _canon_title_type(context.get("title_type", ""))
+        if not any(_canon_title_type(item) == actual_type for item in _as_list(expected_type)):
+            return False
 
     for field in _STRING_FIELDS:
         expected = rule.get(field)

--- a/unshackle/core/utils/tag_overrides.py
+++ b/unshackle/core/utils/tag_overrides.py
@@ -1,0 +1,144 @@
+"""Group tag override rule engine for output filename templates.
+
+Lets the group ``tag`` (the ``-{tag}`` suffix) be swapped for a different value
+when a release matches a set of conditions — for example tagging Russian-only
+releases with a different group name, or using a dedicated tag for a given
+service or dynamic range.
+
+Rules are evaluated against the already-computed filename context, so any value
+present in the template (``lang_tag``, ``source``, ``hdr``, ``resolution``,
+``video`` …) can be used as a condition, in addition to the selected track
+languages.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional, Sequence
+
+from langcodes import Language
+
+from unshackle.core.utilities import is_close_match
+
+log = logging.getLogger(__name__)
+
+# Context fields a rule may match directly. Values are compared
+# case-insensitively; a list value matches if ANY entry matches.
+_STRING_FIELDS = (
+    "lang_tag",
+    "source",
+    "quality",
+    "resolution",
+    "video",
+    "hdr",
+    "hfr",
+    "audio",  # audio codec (e.g. EAC3)
+    "audio_channels",
+    "atmos",
+    "dual",
+    "multi",
+    "edition",
+    "repack",
+)
+
+
+def evaluate_tag_override(
+    rules: list[dict[str, Any]],
+    context: dict[str, Any],
+    audio_languages: Sequence[Language],
+    subtitle_languages: Sequence[Language],
+) -> Optional[str]:
+    """Evaluate group-tag override rules against the filename context.
+
+    Rules are evaluated in order; the first matching rule's ``tag`` is returned,
+    replacing the default group tag. Returns ``None`` when no rule matches.
+
+    Args:
+        rules: List of rule dicts from config, each with conditions and a ``tag``.
+        context: The filename template context (``lang_tag``, ``source``, ``hdr`` …).
+        audio_languages: Languages of the selected audio tracks.
+        subtitle_languages: Languages of the selected subtitle tracks.
+
+    Returns:
+        The overriding tag from the first matching rule, or ``None`` if none match.
+    """
+    for rule in rules:
+        tag = rule.get("tag")
+        if not tag:
+            log.warning("Tag override rule missing 'tag' field, skipping: %s", rule)
+            continue
+
+        if _rule_matches(rule, context, audio_languages, subtitle_languages):
+            log.debug("Tag override rule matched: %s -> %s", rule, tag)
+            return str(tag)
+
+    return None
+
+
+def _as_list(value: Any) -> list:
+    return value if isinstance(value, list) else [value]
+
+
+def _string_matches(expected: Any, actual: Any) -> bool:
+    """Case-insensitive match; a list of expected values matches if any one does."""
+    actual_norm = str(actual or "").lower()
+    return any(str(item).lower() == actual_norm for item in _as_list(expected))
+
+
+def _rule_matches(
+    rule: dict[str, Any],
+    context: dict[str, Any],
+    audio_languages: Sequence[Language],
+    subtitle_languages: Sequence[Language],
+) -> bool:
+    """Check if all conditions in a rule are satisfied (AND logic)."""
+    has_condition = False
+
+    for field in _STRING_FIELDS:
+        expected = rule.get(field)
+        if expected is not None:
+            has_condition = True
+            if not _string_matches(expected, context.get(field, "")):
+                return False
+
+    res_min = rule.get("resolution_min")
+    res_max = rule.get("resolution_max")
+    if res_min is not None or res_max is not None:
+        has_condition = True
+        try:
+            resolution = int(context.get("resolution") or 0)
+        except (TypeError, ValueError):
+            return False
+        if res_min is not None and resolution < int(res_min):
+            return False
+        if res_max is not None and resolution > int(res_max):
+            return False
+
+    audio_lang = rule.get("audio_lang")
+    if audio_lang is not None:
+        has_condition = True
+        if not is_close_match(audio_lang, list(audio_languages)):
+            return False
+
+    subs_lang = rule.get("subs_lang")
+    if subs_lang is not None:
+        has_condition = True
+        if not is_close_match(subs_lang, list(subtitle_languages)):
+            return False
+
+    audio_count_min = rule.get("audio_count_min")
+    if audio_count_min is not None:
+        has_condition = True
+        try:
+            min_count = int(audio_count_min)
+        except (TypeError, ValueError):
+            return False
+        distinct = {str(lang).split("-")[0].lower() for lang in audio_languages if lang}
+        if len(distinct) < min_count:
+            return False
+
+    if not has_condition:
+        log.warning("Tag override rule has no conditions, skipping: %s", rule)
+        return False
+
+    return True

--- a/unshackle/unshackle-example.yaml
+++ b/unshackle/unshackle-example.yaml
@@ -9,6 +9,14 @@
 # Group or username appended to download filenames after a dash.
 tag: "NOGRP"
 
+# Conditionally swap the group tag above for a different value based on rules
+# (e.g. lang_tag, source, hdr, resolution). First matching rule wins.
+# Full condition list and examples in docs/OUTPUT_CONFIG.md.
+# tag_overrides:
+#   rules:
+#     - lang_tag: RUSSiAN
+#       tag: RUGROUP
+
 # --- Output filename & folder templates --- docs/OUTPUT_CONFIG.md
 # Full variable list (35 vars incl. music) and all naming options are
 # documented in docs/OUTPUT_CONFIG.md. If omitted, scene-style defaults are


### PR DESCRIPTION
Adds a `tag_overrides` option that changes the group tag (the `-{tag}` suffix)
based on rules, instead of always using the global `tag`.

I wanted to give Russian-only releases a different group name while keeping the
default tag for everything else. There are also teams that have different tags based on quality (a team for UHD, for example), or a team for movies and another for TV shows.
The rules can also match on other things like
the service, resolution, HDR or media type, so it isn't limited to language.


## How it works

Rules go under `tag_overrides.rules` and are checked top to bottom. The first
rule whose conditions all match wins, and its `tag` replaces the default. If no
rule matches, the normal `tag` is kept.

Conditions are checked against the values already computed for the filename, so
anything you can put in `output_template` works as a condition.

## Conditions

A condition that takes a string also accepts a list, in which case it matches if
any entry matches. Text is matched case-insensitively.

- `title_type`: `movie`, `series` or `music` (also accepts `film`, `episode`, `show`, `song`, `album`)
- `lang_tag`: the value from `language_tags`, e.g. `RUSSiAN`
- `source`: the service tag, e.g. `AMZN`
- `hdr`: the dynamic range, e.g. `DV`, `HDR10`, `HLG`
- `video`: the video codec tag
- `quality` and `resolution`: the quality or exact resolution
- `resolution_min` and `resolution_max`: resolution at least or at most this value
- `audio`: the audio codec tag
- `atmos`, `dual`, `multi`, `edition`, `repack`, `hfr`, `audio_channels`: the matching context value
- `audio_lang` and `subs_lang`: a language present in the audio or subtitles
- `audio_count_min`: at least this many distinct audio languages

`audio_lang` and `subs_lang` use the same fuzzy language matching as
`language_tags`, so `en` also matches `en-US`.

## Example

```yaml
tag: "NOGRP"

language_tags:
  rules:
    - audio: ru
      tag: RUSSiAN

tag_overrides:
  rules:
    # Russian-only movies, put the more specific rule first
    - title_type: movie
      lang_tag: RUSSiAN
      tag: RUMOVIES
    # any other Russian-only release
    - lang_tag: RUSSiAN
      tag: RUGROUP
```

A Russian movie ends with `-RUMOVIES`, a Russian series with `-RUGROUP`, and
anything else keeps `-NOGRP`.

## Files

- `core/utils/tag_overrides.py`: the rule evaluation, written the same way as
  `core/utils/language_tags.py`
- `core/titles/title.py`: adds `title_type` to the context and applies the
  overrides after `lang_tag` is set
- `core/config.py`: reads `tag_overrides`
- `docs/OUTPUT_CONFIG.md` and `unshackle-example.yaml`: docs and an example

## Notes

Without any `tag_overrides` config the behaviour is the same as before. A rule
with no conditions is skipped and logged as a warning, so an empty rule can't
match everything by accident. Checked with ruff and tested manually against the
ordering, case handling, fuzzy language matching and the `title_type` aliases.
