### PR TITLE
feat(proxies): add native V2Ray/Xray proxy provider

### DIFF
--- a/docs/guide/proxies-and-vpn.md
+++ b/docs/guide/proxies-and-vpn.md
@@ -596,6 +596,74 @@ The returned proxy is HTTPS on **port 443**.
     or Gluetun exits, resolve the proxy on the CLI side or use a different provider for API
     jobs. See the developer note below.
 
+## V2Ray / Xray
+
+V2Ray / Xray is a generic proxy platform that supports VMess, VLESS, Trojan, and
+Shadowsocks protocols with extensive transport options (TCP, WebSocket, gRPC, HTTP/2,
+QUIC, HTTPUpgrade) and TLS / XTLS-Reality security layers. The `v2ray` provider spins up
+a local V2Ray or Xray subprocess with an ephemeral SOCKS5 inbound on `127.0.0.1` and
+routes traffic through a user-selected outbound — letting unshackle use any
+V2Ray-compatible server as a proxy.
+
+### Prerequisites
+
+Install **either** [Xray-core](https://github.com/XTLS/Xray-core) **or**
+[V2Ray-core](https://github.com/v2fly/v2ray-core) and make sure the binary is on your
+`PATH`. Xray is the modern, fully-compatible fork and is preferred when both are
+installed; the original `v2ray` binary is used as a fallback.
+
+### Configuration
+
+V2Ray is **config-gated**: a `v2ray:` block under `proxy_providers:` is required to opt
+in (even an empty one). This avoids instantiating a provider for users who have xray
+installed for unrelated reasons.
+
+```yaml
+proxy_providers:
+  v2ray:
+    subscription_url: https://your-provider.example/sub.yaml
+```
+
+Servers can be supplied in four ways (all can coexist):
+
+| Source | Key | Description |
+|--------|-----|-------------|
+| Subscription | `subscription_url` | base64/plain subscription endpoint(s) |
+| Config file | `config_path` | pre-built V2Ray/Xray JSON config file |
+| Inline list | `servers` | list of `vmess://` / `vless://` / `trojan://` / `ss://` URIs |
+| Per-country map | `countries` | `basic`-style country → URI assignment |
+
+### Query format
+
+```shell title="Any server assigned to / detected as US"
+unshackle dl --proxy v2ray:us EXAMPLE 81234567
+```
+
+```shell title="First US server (1-indexed)"
+unshackle dl --proxy v2ray:us:1 EXAMPLE 81234567
+```
+
+```shell title="Server whose remark contains 'tokyo'"
+unshackle dl --proxy v2ray:tokyo EXAMPLE 81234567
+```
+
+```shell title="Direct-URI one-shot (works with an empty v2ray: {} block)"
+unshackle dl --proxy v2ray:vmess://eyJ2IjoiMiIs... EXAMPLE 81234567
+```
+
+### Direct-URI mode
+
+A `vmess://`, `vless://`, `trojan://`, or `ss://` URI can be passed directly after
+`v2ray:` and a one-shot subprocess is spawned for that exact server. This requires a
+minimal `v2ray:` config entry (an empty `v2ray: {}` block is enough) but no server list.
+The same URI passed twice reuses the existing subprocess.
+
+### Auto-loading
+
+V2Ray is loaded whenever a `v2ray:` block exists under `proxy_providers:`. Unlike Hola
+(which auto-loads on binary detection), V2Ray requires this explicit opt-in so users
+with xray installed for unrelated reasons don't get a V2Ray provider on every run.
+
 ## Developer notes
 
 !!! note "Two resolution paths (developers)"

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -671,6 +671,7 @@ the full provider guide. Recognised providers and their exit ports:
 | ExpressVPN | `expressvpn` | browser cookies / token cache | `https://cat:...@...:443` |
 | ProtonVPN | `protonvpn` | TV login or exported cookies | `https://...:4443` (or `:443` Secure Core) |
 | Gluetun | `gluetun` | per-VPN keys/creds | `http://localhost:{port}` (local Docker) |
+| V2Ray / Xray | `v2ray` | subscription / inline URIs / config file | `socks5://127.0.0.1:{port}` (local subprocess) |
 | Hola | *(none, auto)* | none | `http://...:{peer}` |
 
 ```yaml

--- a/tests/core/test_v2ray.py
+++ b/tests/core/test_v2ray.py
@@ -1,0 +1,1627 @@
+"""Unit tests for the V2Ray proxy provider.
+
+Covers:
+- URI parsing for every supported protocol (vmess / vless / trojan / shadowsocks, SIP002 + legacy)
+- Subscription decoding (base64 + plain)
+- Config-file extraction (V2Ray/Xray JSON outbounds)
+- Country detection heuristics (flag emoji, full names, UK alias, TLD fallback)
+- Server selection (by country, by index, by remark, by alias via server_map)
+- V2Ray/Xray config building (inbounds + outbound per protocol)
+- Provider lifecycle: query deduplication, port allocation, cleanup, error paths
+
+These are pure-Python unit tests — no real network, no real subprocess, no real IP
+verification. End-to-end behaviour against a live V2Ray binary lives elsewhere.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from unshackle.core.proxies.proxy import Proxy
+from unshackle.core.proxies.v2ray import (V2Ray, V2RayServer, _b64_decode_loose, _detect_country, build_config,
+                                          build_outbound, fetch_subscription, load_config_file, parse_server_uri)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _b64(s: str) -> str:
+    """Standard base64 encoding for payload construction in test fixtures."""
+    return base64.b64encode(s.encode("utf-8")).decode("ascii")
+
+
+def _make_vmess_uri(
+    *,
+    address: str = "1.2.3.4",
+    port: int = 443,
+    uuid: str = "b831381d-6324-4d53-ad4f-8cda48b30811",
+    remark: str = "🇺🇸 US - Los Angeles",
+    network: str = "ws",
+    path: str = "/ray",
+    host: str = "example.com",
+    tls: str = "tls",
+    sni: str = "example.com",
+    alter_id: int = 0,
+) -> str:
+    payload = {
+        "v": "2",
+        "ps": remark,
+        "add": address,
+        "port": str(port),
+        "id": uuid,
+        "aid": alter_id,
+        "net": network,
+        "type": "none",
+        "host": host,
+        "path": path,
+        "tls": tls,
+        "sni": sni,
+    }
+    return "vmess://" + _b64(json.dumps(payload))
+
+
+def _make_vless_uri(
+    *,
+    address: str = "1.2.3.4",
+    port: int = 443,
+    uuid: str = "b831381d-6324-4d53-ad4f-8cda48b30811",
+    remark: str = "🇯🇵 JP - Tokyo",
+    network: str = "ws",
+    path: str = "/vless",
+    host: str = "jp.example.com",
+    security: str = "tls",
+    sni: str = "jp.example.com",
+    flow: str = "",
+) -> str:
+    query = f"encryption=none&security={security}&type={network}&host={host}&path={path}&sni={sni}"
+    if flow:
+        query += f"&flow={flow}"
+    return f"vless://{uuid}@{address}:{port}?{query}#{remark}"
+
+
+def _make_trojan_uri(
+    *,
+    address: str = "1.2.3.4",
+    port: int = 443,
+    password: str = "secretpass",
+    remark: str = "🇬🇧 UK - London",
+    network: str = "tcp",
+    sni: str = "uk.example.com",
+) -> str:
+    return f"trojan://{password}@{address}:{port}?security=tls&type={network}&sni={sni}#{remark}"
+
+
+def _make_ss_sip002_uri(
+    *,
+    address: str = "1.2.3.4",
+    port: int = 8388,
+    method: str = "aes-256-gcm",
+    password: str = "sspassword",
+    remark: str = "🇩🇪 DE - Berlin",
+) -> str:
+    creds = _b64(f"{method}:{password}")
+    return f"ss://{creds}@{address}:{port}#{remark}"
+
+
+def _make_ss_legacy_uri(
+    *,
+    address: str = "5.6.7.8",
+    port: int = 8388,
+    method: str = "aes-256-gcm",
+    password: str = "sspassword",
+    remark: str = "DE Server",
+) -> str:
+    payload = _b64(f"{method}:{password}@{address}:{port}")
+    return f"ss://{payload}#{remark}"
+
+
+# ---------------------------------------------------------------------------
+# Proxy contract
+# ---------------------------------------------------------------------------
+
+
+def test_v2ray_is_a_proxy_subclass():
+    assert issubclass(V2Ray, Proxy)
+
+
+def test_v2ray_repr_with_no_servers():
+    provider = V2Ray(servers=[])
+    assert repr(provider) == "0 Countries (0 Servers)"
+
+
+def test_v2ray_repr_counts_unique_countries_and_servers():
+    provider = V2Ray(
+        servers=[
+            _make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1"),
+            _make_vmess_uri(remark="🇺🇸 US-East", address="2.2.2.2"),
+            _make_vmess_uri(remark="🇯🇵 JP", address="3.3.3.3"),
+        ]
+    )
+    assert repr(provider) == "2 Countries (3 Servers)"
+
+
+# ---------------------------------------------------------------------------
+# URI parsing — VMess
+# ---------------------------------------------------------------------------
+
+
+def test_parse_vmess_basic_fields():
+    server = parse_server_uri(_make_vmess_uri())
+    assert server is not None
+    assert server.protocol == "vmess"
+    assert server.address == "1.2.3.4"
+    assert server.port == 443
+    assert server.settings["id"] == "b831381d-6324-4d53-ad4f-8cda48b30811"
+    assert server.settings["alterId"] == 0
+    assert server.network == "ws"
+    assert server.stream["security"] == "tls"
+    assert server.stream["network"] == "ws"
+    assert server.stream["wsSettings"]["path"] == "/ray"
+    assert server.stream["wsSettings"]["host"] == "example.com"
+    assert server.stream["tlsSettings"]["serverName"] == "example.com"
+    # TLS verification must default to ON — allowInsecure must NOT be set unless the
+    # share link explicitly carries verify_cert: false.
+    assert "allowInsecure" not in server.stream["tlsSettings"]
+    assert server.country == "us"
+
+
+def test_parse_vmess_allowInsecure_only_when_verify_cert_false():
+    """allowInsecure must only be set when the share link explicitly opts in via verify_cert: false."""
+    payload = {
+        "v": "2", "ps": "test", "add": "1.2.3.4", "port": "443",
+        "id": "b831381d-6324-4d53-ad4f-8cda48b30811", "aid": 0,
+        "net": "ws", "type": "none", "host": "example.com", "path": "/ray",
+        "tls": "tls", "sni": "example.com", "verify_cert": False,
+    }
+    uri = "vmess://" + _b64(json.dumps(payload))
+    server = parse_server_uri(uri)
+    assert server is not None
+    assert server.stream["tlsSettings"]["allowInsecure"] is True
+
+
+def test_parse_vmess_without_tls():
+    uri = _make_vmess_uri(tls="", sni="", host="")
+    server = parse_server_uri(uri)
+    assert server is not None
+    assert server.stream["security"] == "none"
+
+
+def test_parse_vmess_grpc_network():
+    uri = _make_vmess_uri(network="grpc", path="GunService", tls="tls")
+    server = parse_server_uri(uri)
+    assert server is not None
+    assert server.stream["grpcSettings"]["serviceName"] == "GunService"
+
+
+def test_parse_vmess_invalid_base64_returns_none():
+    server = parse_server_uri("vmess://!!!not-base64!!!")
+    assert server is None
+
+
+def test_parse_vmess_missing_address_returns_none():
+    payload = {"v": "2", "ps": "x", "add": "", "port": "443", "id": "x", "aid": 0, "net": "tcp"}
+    server = parse_server_uri("vmess://" + _b64(json.dumps(payload)))
+    assert server is None
+
+
+# ---------------------------------------------------------------------------
+# URI parsing — VLESS
+# ---------------------------------------------------------------------------
+
+
+def test_parse_vless_basic_fields():
+    server = parse_server_uri(_make_vless_uri())
+    assert server is not None
+    assert server.protocol == "vless"
+    assert server.address == "1.2.3.4"
+    assert server.port == 443
+    assert server.settings["id"] == "b831381d-6324-4d53-ad4f-8cda48b30811"
+    assert server.settings["encryption"] == "none"
+    assert server.network == "ws"
+    assert server.stream["security"] == "tls"
+    assert server.stream["wsSettings"]["path"] == "/vless"
+    assert server.stream["tlsSettings"]["serverName"] == "jp.example.com"
+    assert server.country == "jp"
+
+
+def test_parse_vless_reality():
+    uri = (
+        "vless://b831381d-6324-4d53-ad4f-8cda48b30811@1.2.3.4:443?"
+        "encryption=none&security=reality&type=tcp&sni=www.google.com&pbk=ABC&sid=def&fp=chrome"
+        "#Reality"
+    )
+    server = parse_server_uri(uri)
+    assert server is not None
+    assert server.stream["security"] == "reality"
+    assert server.stream["realitySettings"]["publicKey"] == "ABC"
+    assert server.stream["realitySettings"]["shortId"] == "def"
+    assert server.stream["realitySettings"]["fingerprint"] == "chrome"
+
+
+def test_parse_vless_with_flow_xtls_vision():
+    uri = _make_vless_uri(network="tcp", flow="xtls-rprx-vision")
+    server = parse_server_uri(uri)
+    assert server is not None
+    assert server.settings["flow"] == "xtls-rprx-vision"
+
+
+def test_parse_vless_missing_user_returns_none():
+    server = parse_server_uri("vless://@1.2.3.4:443")
+    assert server is None
+
+
+# ---------------------------------------------------------------------------
+# URI parsing — Trojan
+# ---------------------------------------------------------------------------
+
+
+def test_parse_trojan_basic_fields():
+    server = parse_server_uri(_make_trojan_uri())
+    assert server is not None
+    assert server.protocol == "trojan"
+    assert server.address == "1.2.3.4"
+    assert server.port == 443
+    assert server.settings["password"] == "secretpass"
+    assert server.stream["security"] == "tls"
+    assert server.stream["tlsSettings"]["serverName"] == "uk.example.com"
+    assert server.country == "gb"  # UK alias normalised to GB
+
+
+def test_parse_trojan_default_port_is_443():
+    uri = "trojan://pass@host.example#Test"
+    server = parse_server_uri(uri)
+    assert server is not None
+    assert server.port == 443
+
+
+def test_parse_trojan_ws_network():
+    # Build a trojan URI with the WebSocket transport directly — _make_trojan_uri()
+    # doesn't expose the path/host query params, so construct the URI inline.
+    uri = (
+        "trojan://secretpass@1.2.3.4:443?"
+        "security=tls&type=ws&path=/trojan&host=uk.example.com&sni=uk.example.com#WS"
+    )
+    server = parse_server_uri(uri)
+    assert server is not None
+    assert server.network == "ws"
+    assert server.stream["wsSettings"]["path"] == "/trojan"
+
+
+# ---------------------------------------------------------------------------
+# URI parsing — Shadowsocks (SIP002 + legacy)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_shadowsocks_sip002():
+    server = parse_server_uri(_make_ss_sip002_uri())
+    assert server is not None
+    assert server.protocol == "shadowsocks"
+    assert server.address == "1.2.3.4"
+    assert server.port == 8388
+    assert server.settings["method"] == "aes-256-gcm"
+    assert server.settings["password"] == "sspassword"
+    assert server.country == "de"
+
+
+def test_parse_shadowsocks_legacy():
+    server = parse_server_uri(_make_ss_legacy_uri())
+    assert server is not None
+    assert server.protocol == "shadowsocks"
+    assert server.address == "5.6.7.8"
+    assert server.port == 8388
+    assert server.settings["method"] == "aes-256-gcm"
+    assert server.settings["password"] == "sspassword"
+
+
+def test_parse_shadowsocks_plaintext_creds():
+    uri = "ss://aes-256-gcm:plaintextpass@1.2.3.4:8388#Plain"
+    server = parse_server_uri(uri)
+    assert server is not None
+    assert server.settings["method"] == "aes-256-gcm"
+    assert server.settings["password"] == "plaintextpass"
+
+
+def test_parse_shadowsocks_invalid_returns_none():
+    assert parse_server_uri("ss://") is None
+    assert parse_server_uri("ss://!!!invalid") is None
+
+
+# ---------------------------------------------------------------------------
+# URI parsing — misc
+# ---------------------------------------------------------------------------
+
+
+def test_parse_unknown_scheme_returns_none():
+    assert parse_server_uri("https://example.com") is None
+    assert parse_server_uri("") is None
+    assert parse_server_uri("garbage") is None
+
+
+def test_parse_uri_strips_whitespace():
+    uri = "  " + _make_vmess_uri() + "  "
+    server = parse_server_uri(uri)
+    assert server is not None
+
+
+# ---------------------------------------------------------------------------
+# Country detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "remark,expected",
+    [
+        ("🇺🇸 US - Los Angeles", "us"),
+        ("JP - Tokyo", "jp"),
+        ("(DE) Berlin", "de"),
+        ("United Kingdom - London", "gb"),
+        ("Canada East", "ca"),
+        ("UK Server 1", "gb"),  # alias — caught by 2-letter hint path via COUNTRY_CODE_ALIASES
+        ("GB Server 1", "gb"),
+        ("random-server.example.com", None),  # no country hint
+        # Countries that use pycountry common_name (not in ISO name):
+        ("South Korea - Seoul", "kr"),
+        ("Taiwan - Taipei", "tw"),
+        ("Bolivia - La Paz", "bo"),
+        ("Iran - Tehran", "ir"),
+        ("Vietnam - Hanoi", "vn"),
+        # Countries that were NOT in the old hardcoded list — proves the dynamic lookup works:
+        ("Iceland - Reykjavik", "is"),
+        ("Estonia - Tallinn", "ee"),
+        ("Luxembourg", "lu"),
+        ("Nigeria - Lagos", "ng"),
+        ("Kazakhstan", "kz"),
+    ],
+)
+def test_detect_country_from_remark(remark, expected):
+    assert _detect_country(remark) == expected
+
+
+def test_detect_country_tld_fallback():
+    assert _detect_country("", "server.de") == "de"
+    assert _detect_country("", "server.example.com") is None  # .com is not a country TLD
+
+
+# ---------------------------------------------------------------------------
+# Base64 decoding (lenient)
+# ---------------------------------------------------------------------------
+
+
+def test_b64_decode_standard():
+    assert _b64_decode_loose(_b64("hello")) == "hello"
+
+
+def test_b64_decode_urlsafe_no_padding():
+    encoded = base64.urlsafe_b64encode(b"hello").decode("ascii").rstrip("=")
+    assert _b64_decode_loose(encoded) == "hello"
+
+
+def test_b64_decode_invalid_raises():
+    with pytest.raises(ValueError):
+        _b64_decode_loose("!!!not base64!!!")
+
+
+# ---------------------------------------------------------------------------
+# Subscription fetching
+# ---------------------------------------------------------------------------
+
+
+def _fake_response(*, text: str, status: int = 200):
+    response = MagicMock()
+    response.status_code = status
+    response.text = text
+    response.raise_for_status = MagicMock()
+    if status >= 400:
+        response.raise_for_status.side_effect = Exception(f"HTTP {status}")
+    return response
+
+
+def test_fetch_subscription_plain_uris():
+    body = "\n".join(
+        [
+            _make_vmess_uri(remark="🇺🇸 US"),
+            _make_vless_uri(remark="🇯🇵 JP"),
+            "# this is a comment",
+            "",
+            "garbage-line",  # should be skipped, not abort
+        ]
+    )
+    with patch("unshackle.core.proxies.v2ray.requests.get", return_value=_fake_response(text=body)) as mock_get:
+        servers = fetch_subscription("https://sub.example/list")
+    assert len(servers) == 2
+    assert {s.country for s in servers} == {"us", "jp"}
+    mock_get.assert_called_once()
+    # Verify the User-Agent header is set (browser-like, to dodge naive UA filters).
+    _, kwargs = mock_get.call_args
+    assert "User-Agent" in kwargs["headers"]
+
+
+def test_fetch_subscription_base64_encoded():
+    body = "\n".join([_make_vmess_uri(remark="🇩🇪 DE"), _make_trojan_uri(remark="🇬🇧 UK")])
+    encoded = _b64(body)
+    with patch("unshackle.core.proxies.v2ray.requests.get", return_value=_fake_response(text=encoded)):
+        servers = fetch_subscription("https://sub.example/b64")
+    assert len(servers) == 2
+    assert {s.country for s in servers} == {"de", "gb"}
+
+
+def test_fetch_subscription_empty_body():
+    with patch("unshackle.core.proxies.v2ray.requests.get", return_value=_fake_response(text="")):
+        servers = fetch_subscription("https://sub.example/empty")
+    assert servers == []
+
+
+def test_fetch_subscription_propagates_http_errors():
+    with patch("unshackle.core.proxies.v2ray.requests.get", return_value=_fake_response(text="", status=500)):
+        with pytest.raises(Exception):
+            fetch_subscription("https://sub.example/err")
+
+
+# ---------------------------------------------------------------------------
+# Config file loading
+# ---------------------------------------------------------------------------
+
+
+def test_load_config_file_extracts_outbounds(tmp_path: Path):
+    config = {
+        "log": {"loglevel": "warning"},
+        "inbounds": [],
+        "outbounds": [
+            {
+                "tag": "us-proxy",
+                "protocol": "vmess",
+                "settings": {
+                    "vnext": [
+                        {
+                            "address": "1.2.3.4",
+                            "port": 443,
+                            "users": [{"id": "abc", "alterId": 0, "security": "auto"}],
+                        }
+                    ]
+                },
+                "streamSettings": {"network": "ws", "security": "tls", "tlsSettings": {"serverName": "x.com"}},
+            },
+            {
+                "tag": "direct",
+                "protocol": "freedom",
+            },
+        ],
+    }
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps(config))
+    servers = load_config_file(path)
+    assert len(servers) == 1
+    assert servers[0].protocol == "vmess"
+    assert servers[0].address == "1.2.3.4"
+    assert servers[0].port == 443
+    assert servers[0].remark == "us-proxy"
+
+
+def test_load_config_file_handles_each_protocol(tmp_path: Path):
+    config = {
+        "outbounds": [
+            {
+                "protocol": "vless",
+                "settings": {"vnext": [{"address": "h1", "port": 443, "users": [{"id": "u1"}]}]},
+                "streamSettings": {"network": "tcp"},
+            },
+            {
+                "protocol": "trojan",
+                "settings": {"servers": [{"address": "h2", "port": 443, "password": "p2"}]},
+                "streamSettings": {},
+            },
+            {
+                "protocol": "shadowsocks",
+                "settings": {"servers": [{"address": "h3", "port": 8388, "method": "aes-256-gcm", "password": "p3"}]},
+                "streamSettings": {},
+            },
+            {"protocol": "freedom"},
+            {"protocol": "blackhole"},
+        ]
+    }
+    path = tmp_path / "c.json"
+    path.write_text(json.dumps(config))
+    servers = load_config_file(path)
+    assert [s.protocol for s in servers] == ["vless", "trojan", "shadowsocks"]
+
+
+def test_load_config_file_missing_outbounds_raises(tmp_path: Path):
+    path = tmp_path / "bad.json"
+    path.write_text("{}")
+    with pytest.raises(ValueError, match="no 'outbounds' list"):
+        load_config_file(path)
+
+
+def test_load_config_file_invalid_json_raises(tmp_path: Path):
+    path = tmp_path / "bad.json"
+    path.write_text("not json")
+    with pytest.raises(ValueError, match="could not read config file"):
+        load_config_file(path)
+
+
+# ---------------------------------------------------------------------------
+# Config building
+# ---------------------------------------------------------------------------
+
+
+def test_build_outbound_vmess_shape():
+    server = parse_server_uri(_make_vmess_uri())
+    outbound = build_outbound(server, tag="proxy")
+    assert outbound["tag"] == "proxy"
+    assert outbound["protocol"] == "vmess"
+    assert outbound["settings"]["vnext"][0]["address"] == "1.2.3.4"
+    assert outbound["settings"]["vnext"][0]["port"] == 443
+    assert outbound["streamSettings"]["network"] == "ws"
+    assert outbound["streamSettings"]["security"] == "tls"
+
+
+def test_build_outbound_vless_with_flow():
+    server = parse_server_uri(_make_vless_uri(network="tcp", flow="xtls-rprx-vision"))
+    outbound = build_outbound(server)
+    user = outbound["settings"]["vnext"][0]["users"][0]
+    assert user["flow"] == "xtls-rprx-vision"
+
+
+def test_build_outbound_trojan_shape():
+    server = parse_server_uri(_make_trojan_uri())
+    outbound = build_outbound(server)
+    assert outbound["protocol"] == "trojan"
+    assert outbound["settings"]["servers"][0]["password"] == "secretpass"
+
+
+def test_build_outbound_shadowsocks_shape():
+    server = parse_server_uri(_make_ss_sip002_uri())
+    outbound = build_outbound(server)
+    assert outbound["protocol"] == "shadowsocks"
+    assert outbound["settings"]["servers"][0]["method"] == "aes-256-gcm"
+
+
+def test_build_outbound_unsupported_protocol_raises():
+    server = V2RayServer(protocol="bogus", address="x", port=1)
+    with pytest.raises(ValueError, match="Unsupported V2Ray protocol"):
+        build_outbound(server)
+
+
+def test_build_config_has_socks_and_http_inbounds():
+    server = parse_server_uri(_make_vmess_uri())
+    config = build_config(server, socks_port=1080, http_port=1081)
+    inbound_tags = [i["tag"] for i in config["inbounds"]]
+    assert "socks-in" in inbound_tags
+    assert "http-in" in inbound_tags
+    socks = next(i for i in config["inbounds"] if i["tag"] == "socks-in")
+    assert socks["listen"] == "127.0.0.1"
+    assert socks["port"] == 1080
+    assert socks["protocol"] == "socks"
+    # Outbound section has proxy + direct + block
+    outbound_tags = [o["tag"] for o in config["outbounds"]]
+    assert outbound_tags == ["proxy", "direct", "block"]
+    # Routing bypasses private IPs to direct — uses explicit CIDR ranges (not geoip:private,
+    # which requires a geoip.dat file that's often missing from manual installs).
+    private_rule = next(
+        (r for r in config["routing"]["rules"] if r.get("outboundTag") == "direct"), None
+    )
+    assert private_rule is not None
+    assert "127.0.0.0/8" in private_rule["ip"]
+    assert "192.168.0.0/16" in private_rule["ip"]
+    assert "geoip:private" not in private_rule["ip"]
+
+
+def test_build_config_without_http_inbound():
+    server = parse_server_uri(_make_vmess_uri())
+    config = build_config(server, socks_port=1080, http_port=None)
+    assert len(config["inbounds"]) == 1
+    assert config["inbounds"][0]["tag"] == "socks-in"
+
+
+def test_build_config_uses_bind_host_for_inbounds():
+    """bind_host must flow through to the inbound listen addresses, not be hardcoded."""
+    server = parse_server_uri(_make_vmess_uri())
+    config = build_config(server, socks_port=1080, http_port=1081, bind_host="0.0.0.0")
+    for inbound in config["inbounds"]:
+        assert inbound["listen"] == "0.0.0.0"
+
+
+def test_build_config_default_bind_host_is_localhost():
+    server = parse_server_uri(_make_vmess_uri())
+    config = build_config(server, socks_port=1080, http_port=1081)
+    for inbound in config["inbounds"]:
+        assert inbound["listen"] == "127.0.0.1"
+
+
+# ---------------------------------------------------------------------------
+# Provider: construction + server loading
+# ---------------------------------------------------------------------------
+
+
+def test_provider_loads_inline_servers():
+    provider = V2Ray(
+        servers=[
+            _make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1"),
+            _make_vless_uri(remark="🇯🇵 JP", address="2.2.2.2"),
+        ]
+    )
+    assert len(provider.servers) == 2
+    assert {s.country for s in provider.servers} == {"us", "jp"}
+
+
+def test_provider_dedupes_identical_servers():
+    uri = _make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1")
+    provider = V2Ray(servers=[uri, uri, uri])
+    assert len(provider.servers) == 1
+
+
+def test_provider_accepts_pre_parsed_dicts():
+    server_dict = {
+        "protocol": "vmess",
+        "address": "9.9.9.9",
+        "port": 443,
+        "remark": "🇫🇷 FR",
+        "settings": {"id": "x", "alterId": 0, "security": "auto"},
+        "network": "tcp",
+        "stream": {"network": "tcp", "security": "none"},
+        "country": "fr",
+    }
+    provider = V2Ray(servers=[server_dict])
+    assert len(provider.servers) == 1
+    assert provider.servers[0].country == "fr"
+
+
+def test_provider_loads_subscription(tmp_path: Path):
+    body = _make_vmess_uri(remark="🇺🇸 US") + "\n" + _make_vless_uri(remark="🇯🇵 JP")
+    response = _fake_response(text=body)
+    with patch("unshackle.core.proxies.v2ray.requests.get", return_value=response):
+        provider = V2Ray(subscription_url="https://sub.example/list")
+        # Subscriptions are loaded lazily on first get_proxy() call
+        provider._ensure_subscriptions_loaded()
+    assert len(provider.servers) == 2
+
+
+def test_provider_loads_multiple_subscriptions():
+    body1 = _make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1")
+    body2 = _make_vless_uri(remark="🇯🇵 JP", address="2.2.2.2")
+    responses = [_fake_response(text=body1), _fake_response(text=body2)]
+    with patch("unshackle.core.proxies.v2ray.requests.get", side_effect=responses):
+        provider = V2Ray(subscription_url=["https://sub.example/1", "https://sub.example/2"])
+        provider._ensure_subscriptions_loaded()
+    assert len(provider.servers) == 2
+
+
+def test_provider_subscription_failure_does_not_abort_other_sources():
+    body = _make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1")
+    good_response = _fake_response(text=body)
+    with patch(
+        "unshackle.core.proxies.v2ray.requests.get",
+        side_effect=[Exception("network down"), good_response],
+    ):
+        provider = V2Ray(
+            subscription_url=["https://sub.example/broken", "https://sub.example/ok"]
+        )
+        provider._ensure_subscriptions_loaded()
+    # The failed subscription is logged + skipped; the second one's server still loaded.
+    assert len(provider.servers) == 1
+
+
+def test_provider_loads_config_file(tmp_path: Path):
+    config = {
+        "outbounds": [
+            {
+                "tag": "us-1",
+                "protocol": "vmess",
+                "settings": {
+                    "vnext": [
+                        {
+                            "address": "1.2.3.4",
+                            "port": 443,
+                            "users": [{"id": "abc", "alterId": 0, "security": "auto"}],
+                        }
+                    ]
+                },
+                "streamSettings": {"network": "ws", "security": "tls"},
+            }
+        ]
+    }
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps(config))
+    provider = V2Ray(config_path=path)
+    assert len(provider.servers) == 1
+    assert provider.servers[0].address == "1.2.3.4"
+
+
+def test_provider_invalid_proxy_scheme_raises():
+    with pytest.raises(ValueError, match="proxy_scheme must be one of"):
+        V2Ray(servers=[], proxy_scheme="bogus")
+
+
+def test_provider_explicit_binary_must_exist():
+    with pytest.raises(FileNotFoundError, match="configured binary not found"):
+        V2Ray(servers=[], binary="/no/such/binary")
+
+
+# ---------------------------------------------------------------------------
+# Provider: server selection
+# ---------------------------------------------------------------------------
+
+
+def _make_provider_with_servers() -> V2Ray:
+    return V2Ray(
+        servers=[
+            _make_vmess_uri(remark="🇺🇸 US - Los Angeles", address="1.1.1.1"),
+            _make_vmess_uri(remark="🇺🇸 US - New York", address="2.2.2.2"),
+            _make_vless_uri(remark="🇯🇵 JP - Tokyo", address="3.3.3.3"),
+            _make_trojan_uri(remark="🇬🇧 UK - London", address="4.4.4.4"),
+            _make_ss_sip002_uri(remark="🇩🇪 DE - Berlin", address="5.5.5.5"),
+        ]
+    )
+
+
+def test_select_by_country_returns_first_match():
+    provider = _make_provider_with_servers()
+    server = provider._select_server("us")
+    assert server is not None
+    assert server.country == "us"
+    assert server.address == "1.1.1.1"  # first US server
+
+
+def test_select_by_country_and_index():
+    provider = _make_provider_with_servers()
+    server = provider._select_server("us:2")
+    assert server is not None
+    assert server.address == "2.2.2.2"  # second US server
+
+
+def test_select_by_index_only_returns_first_overall():
+    provider = _make_provider_with_servers()
+    server = provider._select_server("1")
+    assert server is not None
+    assert server.address == "1.1.1.1"
+
+
+def test_select_by_remark_substring():
+    provider = _make_provider_with_servers()
+    server = provider._select_server("tokyo")
+    assert server is not None
+    assert server.address == "3.3.3.3"
+
+
+def test_select_by_country_and_remark():
+    provider = _make_provider_with_servers()
+    server = provider._select_server("us:new york")
+    assert server is not None
+    assert server.address == "2.2.2.2"
+
+
+def test_select_unknown_country_returns_none():
+    provider = _make_provider_with_servers()
+    assert provider._select_server("zz") is None
+
+
+def test_select_index_out_of_range_returns_none():
+    provider = _make_provider_with_servers()
+    assert provider._select_server("us:99") is None
+
+
+def test_select_uses_server_map_alias():
+    provider = _make_provider_with_servers()
+    provider.server_map = {"stream-us": "us:2"}
+    server = provider._select_server("stream-us")
+    assert server is not None
+    assert server.address == "2.2.2.2"
+
+
+def test_select_handles_uk_alias():
+    provider = _make_provider_with_servers()
+    server = provider._select_server("gb")
+    assert server is not None
+    assert server.address == "4.4.4.4"
+
+
+def test_select_with_full_country_name():
+    provider = _make_provider_with_servers()
+    server = provider._select_server("japan")
+    assert server is not None
+    assert server.address == "3.3.3.3"
+
+
+# ---------------------------------------------------------------------------
+# Provider: get_proxy lifecycle (mocked subprocess)
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_process():
+    """A MagicMock that looks like a running subprocess.Popen."""
+    process = MagicMock()
+    process.poll.return_value = None  # None == still running
+    process.pid = 12345
+    process.stderr = MagicMock()
+    process.stderr.read1.return_value = b""
+    return process
+
+
+def test_get_proxy_no_binary_raises_environment_error():
+    provider = V2Ray(servers=[_make_vmess_uri()])
+    provider.binary = None
+    with pytest.raises(EnvironmentError, match="V2Ray/Xray binary not found"):
+        provider.get_proxy("us")
+
+
+def test_get_proxy_no_servers_raises_value_error():
+    provider = V2Ray(servers=[])
+    provider.binary = Path("/fake/xray")  # bypass binary check
+    with pytest.raises(ValueError, match="no servers configured"):
+        provider.get_proxy("us")
+
+
+def test_get_proxy_empty_query_raises_value_error():
+    provider = V2Ray(servers=[_make_vmess_uri()])
+    provider.binary = Path("/fake/xray")
+    with pytest.raises(ValueError, match="empty query"):
+        provider.get_proxy("")
+
+
+def test_get_proxy_unknown_query_returns_none():
+    provider = V2Ray(servers=[_make_vmess_uri()])
+    provider.binary = Path("/fake/xray")
+    # Don't actually spawn — patch _spawn_process so we never need a real binary.
+    with patch.object(V2Ray, "_spawn_process"), \
+         patch.object(V2Ray, "_wait_for_ready", return_value=True), \
+         patch.object(V2Ray, "_verify_proxy"), \
+         patch.object(V2Ray, "_is_port_in_use", return_value=False):
+        # No server matches "zz" -> _select_server returns None -> get_proxy returns None.
+        assert provider.get_proxy("zz") is None
+
+
+def _patch_lifecycle(provider: V2Ray, *, alive: bool = True, ready: bool = True):
+    """Patch the subprocess lifecycle so get_proxy works without a real binary.
+
+    Returns a 6-tuple of ``patch.object`` context managers (in a fixed order) that the
+    caller enters with a single ``with`` block. The order matches the production code
+    path: spawn -> wait_for_ready -> verify_proxy, plus _is_process_alive / _is_port_in_use
+    / _kill_process for the reuse / cleanup paths.
+    """
+    process = _make_mock_process()
+    if not alive:
+        process.poll.return_value = 1
+
+    def fake_spawn(config, socks_port, http_port, server):
+        # Mirror the dict shape returned by the real _spawn_process() — no extra keys,
+        # so tests that introspect the dict see exactly what production would produce.
+        return {
+            "process": process,
+            "config_path": Path(f"/tmp/fake-{socks_port}.json"),
+            "socks_port": socks_port,
+            "http_port": http_port,
+            "pid": 12345,
+            "started_at": 0.0,
+            "verified": False,
+        }
+
+    return (
+        patch.object(V2Ray, "_spawn_process", side_effect=fake_spawn),
+        patch.object(V2Ray, "_wait_for_ready", return_value=ready),
+        patch.object(V2Ray, "_verify_proxy"),
+        patch.object(V2Ray, "_is_process_alive", return_value=alive),
+        patch.object(V2Ray, "_is_port_in_use", return_value=False),
+        patch.object(V2Ray, "_kill_process"),
+    )
+
+
+def test_get_proxy_returns_socks5_uri_by_default():
+    provider = V2Ray(servers=[_make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1")])
+    provider.binary = Path("/fake/xray")
+    patches = _patch_lifecycle(provider)
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+        uri = provider.get_proxy("us")
+    assert uri is not None
+    assert uri.startswith("socks5://127.0.0.1:")
+    port = int(uri.rsplit(":", 1)[1])
+    assert port >= 11080
+
+
+def test_get_proxy_returns_http_uri_when_configured():
+    provider = V2Ray(
+        servers=[_make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1")],
+        proxy_scheme="http",
+    )
+    provider.binary = Path("/fake/xray")
+    patches = _patch_lifecycle(provider)
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+        uri = provider.get_proxy("us")
+    assert uri is not None
+    assert uri.startswith("http://127.0.0.1:")
+
+
+def test_get_proxy_reuses_existing_subprocess_for_same_query():
+    provider = V2Ray(servers=[_make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1")])
+    provider.binary = Path("/fake/xray")
+    patches = _patch_lifecycle(provider)
+    with patches[0] as spawn_patch, patches[1], patches[2], patches[3], patches[4], patches[5]:
+        uri1 = provider.get_proxy("us")
+        uri2 = provider.get_proxy("us")
+    assert uri1 == uri2
+    spawn_patch.assert_called_once()  # second call reuses the existing subprocess
+
+
+def test_get_proxy_startup_failure_raises_runtime_error():
+    provider = V2Ray(servers=[_make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1")])
+    provider.binary = Path("/fake/xray")
+    patches = _patch_lifecycle(provider, ready=False)
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5] as kill_patch:
+        with pytest.raises(RuntimeError, match="V2Ray subprocess failed to start"):
+            provider.get_proxy("us")
+    # The failed subprocess is killed and removed from the active dict.
+    kill_patch.assert_called_once()
+
+
+def test_get_proxy_startup_failure_includes_subprocess_output():
+    """The RuntimeError must include the actual xray/v2ray stderr so users can diagnose."""
+    provider = V2Ray(servers=[_make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1")])
+    provider.binary = Path("/fake/xray")
+
+    # Patch _wait_for_ready to return False AND set exit_output on the process_info,
+    # simulating a dead process whose output was captured.
+    def fake_wait(self, socks_port, *, timeout):
+        for info in self._active.values():
+            if info.get("socks_port") == socks_port:
+                info["exit_output"] = "xray: failed to load geoip.dat: file not found"
+        return False
+
+    process = _make_mock_process()
+    with patch.object(V2Ray, "_spawn_process", side_effect=lambda c, s, h, srv: {
+            "process": process, "config_path": Path(f"/tmp/fake-{s}.json"),
+            "socks_port": s, "http_port": h, "pid": 12345, "started_at": 0.0, "verified": False,
+        }), \
+         patch.object(V2Ray, "_wait_for_ready", fake_wait), \
+         patch.object(V2Ray, "_verify_proxy"), \
+         patch.object(V2Ray, "_is_process_alive", return_value=False), \
+         patch.object(V2Ray, "_is_port_in_use", return_value=False), \
+         patch.object(V2Ray, "_kill_process"):
+        with pytest.raises(RuntimeError, match="failed to load geoip.dat"):
+            provider.get_proxy("us")
+
+
+def test_get_proxy_socks5h_scheme_supported():
+    provider = V2Ray(
+        servers=[_make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1")],
+        proxy_scheme="socks5h",
+    )
+    provider.binary = Path("/fake/xray")
+    patches = _patch_lifecycle(provider)
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+        uri = provider.get_proxy("us")
+    assert uri.startswith("socks5h://127.0.0.1:")
+
+
+# ---------------------------------------------------------------------------
+# Provider: port allocation + cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_allocate_ports_returns_distinct_pair():
+    provider = V2Ray(servers=[])
+    with patch.object(V2Ray, "_is_port_in_use", return_value=False):
+        socks, http = provider._allocate_ports()
+    assert socks == 11080
+    assert http == 11081
+    assert socks != http
+
+
+def test_allocate_ports_skips_used_ports():
+    provider = V2Ray(servers=[])
+    provider._active = {
+        "k1": {"socks_port": 11080, "http_port": 11081},
+    }
+    used_ports = {11080, 11081}
+
+    def fake_in_use(port):
+        return port in used_ports
+
+    with patch.object(V2Ray, "_is_port_in_use", side_effect=fake_in_use):
+        socks, http = provider._allocate_ports()
+    assert socks not in used_ports
+    assert http not in used_ports
+    assert http == socks + 1
+
+
+def test_cleanup_kills_every_active_subprocess():
+    provider = V2Ray(servers=[])
+    provider._active = {
+        "us": {"process": _make_mock_process(), "config_path": None, "socks_port": 1, "http_port": 2},
+        "jp": {"process": _make_mock_process(), "config_path": None, "socks_port": 3, "http_port": 4},
+    }
+    with patch.object(V2Ray, "_kill_process") as kill_patch:
+        provider.cleanup()
+    assert kill_patch.call_count == 2
+    assert provider._active == {}
+
+
+def test_cleanup_is_idempotent():
+    provider = V2Ray(servers=[])
+    with patch.object(V2Ray, "_kill_process"):
+        provider.cleanup()
+        provider.cleanup()  # second call is a no-op
+    assert provider._active == {}
+
+
+def test_kill_process_terminates_and_unlinks_config(tmp_path: Path):
+    provider = V2Ray(servers=[])
+    process = _make_mock_process()
+    config_path = tmp_path / "config-12345.json"
+    config_path.write_text('{"sensitive": "creds"}')
+    info = {
+        "process": process,
+        "config_path": config_path,
+        "socks_port": 12345,
+        "http_port": 12346,
+        "pid": 12345,
+    }
+    provider._kill_process(info)
+    process.terminate.assert_called_once()
+    process.wait.assert_called()
+    assert not config_path.exists()
+
+
+def test_kill_process_kills_when_terminate_hangs():
+    provider = V2Ray(servers=[])
+    process = _make_mock_process()
+    process.wait.side_effect = [subprocess.TimeoutExpired("x", 5), None]
+    info = {"process": process, "config_path": None, "socks_port": 1, "http_port": 2, "pid": 99}
+    provider._kill_process(info)
+    process.kill.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Provider: last_connection_display (replaces get_connection_info)
+# ---------------------------------------------------------------------------
+
+
+def test_last_connection_display_returns_none_before_any_connection():
+    provider = V2Ray(servers=[])
+    assert provider.last_connection_display() is None
+
+
+def test_last_connection_display_shows_label_and_ip():
+    """After spawning, last_connection_display returns '(label) ip' for dl.py to print."""
+    provider = V2Ray(servers=[_make_vmess_uri(remark="🇺🇸 US - LA", address="1.1.1.1")])
+    provider.binary = Path("/fake/xray")
+    patches = _patch_lifecycle(provider)
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+        provider.get_proxy("us")
+    # Simulate IP verification having run (sets public_ip on the process info)
+    provider._last_connection["public_ip"] = "216.185.57.75"
+    display = provider.last_connection_display()
+    assert display is not None
+    assert "🇺🇸 US - LA" in display
+    assert "216.185.57.75" in display
+
+
+def test_last_connection_display_shows_label_without_ip():
+    """If IP verification hasn't run yet, just show the label."""
+    provider = V2Ray(servers=[_make_vmess_uri(remark="🇯🇵 JP", address="1.1.1.1")])
+    provider.binary = Path("/fake/xray")
+    patches = _patch_lifecycle(provider)
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+        provider.get_proxy("jp")
+    display = provider.last_connection_display()
+    assert display is not None
+    assert "🇯🇵 JP" in display
+    # No IP since verify wasn't called
+    assert "216.185" not in display
+
+
+def test_v2ray_does_not_implement_get_connection_info():
+    """V2Ray must NOT implement get_connection_info — dl.py would show 'VPN Connected'
+    which is misleading for a proxy. Instead it implements last_connection_display."""
+    provider = V2Ray(servers=[])
+    assert not hasattr(provider, "get_connection_info"), (
+        "V2Ray should not implement get_connection_info — it triggers the 'VPN Connected' "
+        "display path in dl.py, which is wrong for a proxy provider."
+    )
+    assert hasattr(provider, "last_connection_display")
+
+
+# ---------------------------------------------------------------------------
+# Provider: integration with resolve_proxy
+# ---------------------------------------------------------------------------
+
+
+def test_v2ray_registered_in_resolve_initialize():
+    """V2Ray must be instantiated when ``proxy_providers.v2ray`` is set in config."""
+    import unshackle.core.proxies.v2ray as v2ray_module
+    from unshackle.core.proxies import resolve
+
+    main_config = MagicMock()
+    main_config.proxy_providers = {
+        "v2ray": {"subscription_url": "https://sub.example/list"},
+    }
+    with patch.object(v2ray_module, "V2Ray", side_effect=lambda **kw: MagicMock(name="V2Ray", kwargs=kw)) as V2RayMock, \
+         patch("unshackle.core.binaries.HolaProxy", None), \
+         patch("unshackle.core.config.config", main_config):
+        # initialize_proxy_providers() re-imports V2Ray from the module at call time,
+        # so the patch above is picked up automatically.
+        resolve.initialize_proxy_providers()
+
+    assert V2RayMock.called, "V2Ray constructor was never invoked"
+    assert V2RayMock.call_args.kwargs == {"subscription_url": "https://sub.example/list"}
+
+
+def test_v2ray_loads_when_yaml_block_present():
+    """V2Ray is loaded when a ``v2ray:`` block exists under proxy_providers (even empty)."""
+    import unshackle.core.proxies.v2ray as v2ray_module
+    from unshackle.core.proxies import resolve
+
+    main_config = MagicMock()
+    main_config.proxy_providers = {"v2ray": {}}  # empty block — enough to opt in
+
+    with patch.object(v2ray_module, "V2Ray", side_effect=lambda **kw: MagicMock(name="V2Ray", kwargs=kw)) as V2RayMock, \
+         patch("unshackle.core.binaries.HolaProxy", None), \
+         patch("unshackle.core.config.config", main_config):
+        resolve.initialize_proxy_providers()
+
+    assert V2RayMock.called, "V2Ray should load when a v2ray: block exists"
+    assert V2RayMock.call_args.kwargs == {}
+
+
+def test_v2ray_not_loaded_without_yaml_block_even_if_binary_present():
+    """V2Ray is NOT auto-loaded on binary detection — a ``v2ray:`` block is required.
+
+    This is a deliberate design choice (per maintainer feedback) so users who have xray
+    installed for unrelated reasons don't get a V2Ray provider on every run.
+    """
+    import unshackle.core.proxies.v2ray as v2ray_module
+    from unshackle.core.proxies import resolve
+
+    main_config = MagicMock()
+    main_config.proxy_providers = {}  # no v2ray block
+
+    fake_binary = Path("/usr/local/bin/xray")
+    with patch.object(v2ray_module, "V2Ray", side_effect=lambda **kw: MagicMock(name="V2Ray", kwargs=kw)) as V2RayMock, \
+         patch("unshackle.core.binaries.Xray", fake_binary), \
+         patch("unshackle.core.binaries.V2Ray", None), \
+         patch("unshackle.core.binaries.HolaProxy", None), \
+         patch("unshackle.core.config.config", main_config):
+        resolve.initialize_proxy_providers()
+
+    assert not V2RayMock.called, "V2Ray should NOT auto-load without a v2ray: block"
+
+
+def test_v2ray_loads_with_yaml_config_when_binary_present():
+    """When both YAML config AND binary are present, V2Ray loads once with the YAML config."""
+    import unshackle.core.proxies.v2ray as v2ray_module
+    from unshackle.core.proxies import resolve
+
+    main_config = MagicMock()
+    main_config.proxy_providers = {
+        "v2ray": {"subscription_url": "https://sub.example/list"},
+    }
+
+    fake_binary = Path("/usr/local/bin/xray")
+    with patch.object(v2ray_module, "V2Ray", side_effect=lambda **kw: MagicMock(name="V2Ray", kwargs=kw)) as V2RayMock, \
+         patch("unshackle.core.binaries.Xray", fake_binary), \
+         patch("unshackle.core.binaries.V2Ray", None), \
+         patch("unshackle.core.binaries.HolaProxy", None), \
+         patch("unshackle.core.config.config", main_config):
+        resolve.initialize_proxy_providers()
+
+    assert V2RayMock.call_count == 1, "V2Ray should be loaded exactly once"
+    assert V2RayMock.call_args.kwargs == {"subscription_url": "https://sub.example/list"}
+
+
+# ---------------------------------------------------------------------------
+# Provider: basic-style countries map (per-country URI assignment)
+# ---------------------------------------------------------------------------
+
+
+def test_countries_map_loads_single_uri_per_country():
+    provider = V2Ray(
+        countries={
+            "us": _make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1"),
+            "jp": _make_vless_uri(remark="🇯🇵 JP", address="2.2.2.2"),
+        }
+    )
+    assert set(provider.country_servers.keys()) == {"us", "jp"}
+    assert len(provider.country_servers["us"]) == 1
+    assert provider.country_servers["us"][0].address == "1.1.1.1"
+    assert provider.country_servers["jp"][0].address == "2.2.2.2"
+
+
+def test_countries_map_loads_list_of_uris_per_country():
+    provider = V2Ray(
+        countries={
+            "us": [
+                _make_vmess_uri(remark="🇺🇸 US-1", address="1.1.1.1"),
+                _make_vmess_uri(remark="🇺🇸 US-2", address="2.2.2.2"),
+                _make_vless_uri(remark="🇺🇸 US-3", address="3.3.3.3"),
+            ],
+        }
+    )
+    assert len(provider.country_servers["us"]) == 3
+    addresses = [s.address for s in provider.country_servers["us"]]
+    assert addresses == ["1.1.1.1", "2.2.2.2", "3.3.3.3"]
+
+
+def test_countries_map_skips_unparseable_uris():
+    provider = V2Ray(
+        countries={
+            "us": [
+                _make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1"),
+                "garbage-not-a-uri",
+                "vmess://!!!invalid-base64!!!",
+                _make_vless_uri(remark="🇺🇸 US-2", address="2.2.2.2"),
+            ],
+        }
+    )
+    # Only the two valid URIs loaded; bad ones skipped with a warning.
+    assert len(provider.country_servers["us"]) == 2
+    assert provider.country_servers["us"][0].address == "1.1.1.1"
+    assert provider.country_servers["us"][1].address == "2.2.2.2"
+
+
+def test_countries_map_rejects_non_dict():
+    with pytest.raises(TypeError, match="'countries' must be a dict"):
+        V2Ray(countries="not a dict")  # type: ignore[arg-type]
+
+
+def test_countries_map_skips_non_string_non_list_values():
+    provider = V2Ray(
+        countries={
+            "us": _make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1"),
+            "bad": 12345,  # unsupported type — skipped with warning
+            "jp": _make_vless_uri(remark="🇯🇵 JP", address="2.2.2.2"),
+        }
+    )
+    assert set(provider.country_servers.keys()) == {"us", "jp"}
+
+
+def test_countries_map_forces_country_to_match_key():
+    """A URI whose auto-detected country differs from the map key gets overridden."""
+    # This vmess URI's remark says "🇺🇸 US" but we assign it to "jp" in the map.
+    provider = V2Ray(
+        countries={
+            "jp": _make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1"),
+        }
+    )
+    assert provider.country_servers["jp"][0].country == "jp"
+
+
+def test_countries_map_supports_arbitrary_alias_keys():
+    """Keys don't have to be country codes — any alias works."""
+    provider = V2Ray(
+        countries={
+            "stream-us": _make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1"),
+            "home": _make_vless_uri(remark="🇯🇵 JP", address="2.2.2.2"),
+        }
+    )
+    assert set(provider.country_servers.keys()) == {"stream-us", "home"}
+
+
+def test_select_from_countries_map_by_country():
+    provider = V2Ray(
+        countries={
+            "us": _make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1"),
+            "jp": _make_vless_uri(remark="🇯🇵 JP", address="2.2.2.2"),
+        }
+    )
+    server = provider._select_server("us")
+    assert server is not None
+    assert server.address == "1.1.1.1"
+
+
+def test_select_from_countries_map_by_index():
+    provider = V2Ray(
+        countries={
+            "us": [
+                _make_vmess_uri(remark="🇺🇸 US-1", address="1.1.1.1"),
+                _make_vmess_uri(remark="🇺🇸 US-2", address="2.2.2.2"),
+            ],
+        }
+    )
+    server = provider._select_server("us:2")
+    assert server is not None
+    assert server.address == "2.2.2.2"
+
+
+def test_select_from_countries_map_by_alias():
+    provider = V2Ray(
+        countries={
+            "stream-us": _make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1"),
+        }
+    )
+    server = provider._select_server("stream-us")
+    assert server is not None
+    assert server.address == "1.1.1.1"
+
+
+def test_countries_map_takes_priority_over_flat_list():
+    """If both ``servers`` and ``countries`` are configured, the country map wins."""
+    provider = V2Ray(
+        servers=[_make_vmess_uri(remark="🇺🇸 US-from-flat-list", address="9.9.9.9")],
+        countries={
+            "us": _make_vmess_uri(remark="🇺🇸 US-from-map", address="1.1.1.1"),
+        },
+    )
+    server = provider._select_server("us")
+    assert server is not None
+    assert server.address == "1.1.1.1"  # from the map, not the flat list
+
+
+def test_countries_map_repr_counts_both_pools():
+    provider = V2Ray(
+        servers=[_make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1")],
+        countries={
+            "jp": _make_vless_uri(remark="🇯🇵 JP", address="2.2.2.2"),
+            "de": _make_ss_sip002_uri(remark="🇩🇪 DE", address="3.3.3.3"),
+        },
+    )
+    # 3 countries (us from flat list + jp + de from map), 3 servers total.
+    assert repr(provider) == "3 Countries (3 Servers)"
+
+
+def test_get_proxy_with_countries_map_returns_socks5_uri():
+    provider = V2Ray(
+        countries={
+            "us": _make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1"),
+        }
+    )
+    provider.binary = Path("/fake/xray")
+    patches = _patch_lifecycle(provider)
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+        uri = provider.get_proxy("us")
+    assert uri is not None
+    assert uri.startswith("socks5://127.0.0.1:")
+
+
+# ---------------------------------------------------------------------------
+# Provider: direct-URI mode (--proxy v2ray:vmess://...)
+# ---------------------------------------------------------------------------
+
+
+def test_is_v2ray_uri_detects_all_schemes():
+    from unshackle.core.proxies.v2ray import _is_v2ray_uri
+
+    assert _is_v2ray_uri("vmess://abc")
+    assert _is_v2ray_uri("vless://abc@host:443")
+    assert _is_v2ray_uri("trojan://pass@host:443")
+    assert _is_v2ray_uri("ss://abc")
+    assert _is_v2ray_uri("  vmess://abc  ")  # whitespace is stripped
+    assert not _is_v2ray_uri("us")
+    assert not _is_v2ray_uri("us:1")
+    assert not _is_v2ray_uri("https://example.com")
+    assert not _is_v2ray_uri("socks5://127.0.0.1:1080")
+    assert not _is_v2ray_uri("")
+
+
+def test_get_proxy_with_direct_vmess_uri_spawns_subprocess():
+    """``--proxy v2ray:vmess://...`` spawns a one-shot subprocess for that URI."""
+    provider = V2Ray(servers=[])  # no preloaded servers — direct-URI mode still works
+    provider.binary = Path("/fake/xray")
+    uri = _make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1")
+    patches = _patch_lifecycle(provider)
+    with patches[0] as spawn_patch, patches[1], patches[2], patches[3], patches[4], patches[5]:
+        result = provider.get_proxy(uri)
+    assert result is not None
+    assert result.startswith("socks5://127.0.0.1:")
+    spawn_patch.assert_called_once()
+    # Verify the spawned server matches the URI we passed in.
+    spawned_server = spawn_patch.call_args.args[3]  # 4th positional arg is `server`
+    assert spawned_server.protocol == "vmess"
+    assert spawned_server.address == "1.1.1.1"
+
+
+def test_get_proxy_with_direct_vless_uri_spawns_subprocess():
+    provider = V2Ray(servers=[])
+    provider.binary = Path("/fake/xray")
+    uri = _make_vless_uri(remark="🇯🇵 JP", address="2.2.2.2")
+    patches = _patch_lifecycle(provider)
+    with patches[0] as spawn_patch, patches[1], patches[2], patches[3], patches[4], patches[5]:
+        result = provider.get_proxy(uri)
+    assert result is not None
+    spawned_server = spawn_patch.call_args.args[3]
+    assert spawned_server.protocol == "vless"
+    assert spawned_server.address == "2.2.2.2"
+
+
+def test_get_proxy_with_direct_trojan_uri_spawns_subprocess():
+    provider = V2Ray(servers=[])
+    provider.binary = Path("/fake/xray")
+    uri = _make_trojan_uri(remark="🇬🇧 UK", address="3.3.3.3")
+    patches = _patch_lifecycle(provider)
+    with patches[0] as spawn_patch, patches[1], patches[2], patches[3], patches[4], patches[5]:
+        result = provider.get_proxy(uri)
+    assert result is not None
+    spawned_server = spawn_patch.call_args.args[3]
+    assert spawned_server.protocol == "trojan"
+    assert spawned_server.address == "3.3.3.3"
+
+
+def test_get_proxy_with_direct_ss_uri_spawns_subprocess():
+    provider = V2Ray(servers=[])
+    provider.binary = Path("/fake/xray")
+    uri = _make_ss_sip002_uri(remark="🇩🇪 DE", address="4.4.4.4")
+    patches = _patch_lifecycle(provider)
+    with patches[0] as spawn_patch, patches[1], patches[2], patches[3], patches[4], patches[5]:
+        result = provider.get_proxy(uri)
+    assert result is not None
+    spawned_server = spawn_patch.call_args.args[3]
+    assert spawned_server.protocol == "shadowsocks"
+    assert spawned_server.address == "4.4.4.4"
+
+
+def test_get_proxy_direct_uri_works_without_any_servers_configured():
+    """Direct-URI mode doesn't require subscription_url / config_path / servers."""
+    provider = V2Ray()  # completely empty config
+    provider.binary = Path("/fake/xray")
+    uri = _make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1")
+    patches = _patch_lifecycle(provider)
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+        result = provider.get_proxy(uri)
+    assert result is not None
+
+
+def test_get_proxy_direct_uri_reuses_subprocess_for_same_uri():
+    """Passing the same URI twice reuses the existing subprocess."""
+    provider = V2Ray(servers=[])
+    provider.binary = Path("/fake/xray")
+    uri = _make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1")
+    patches = _patch_lifecycle(provider)
+    with patches[0] as spawn_patch, patches[1], patches[2], patches[3], patches[4], patches[5]:
+        result1 = provider.get_proxy(uri)
+        result2 = provider.get_proxy(uri)
+    assert result1 == result2
+    spawn_patch.assert_called_once()  # second call reuses
+
+
+def test_get_proxy_direct_uri_different_uris_get_different_subprocesses():
+    provider = V2Ray(servers=[])
+    provider.binary = Path("/fake/xray")
+    uri1 = _make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1")
+    uri2 = _make_vless_uri(remark="🇯🇵 JP", address="2.2.2.2")
+    patches = _patch_lifecycle(provider)
+    with patches[0] as spawn_patch, patches[1], patches[2], patches[3], patches[4], patches[5]:
+        result1 = provider.get_proxy(uri1)
+        result2 = provider.get_proxy(uri2)
+    assert result1 != result2  # different ports
+    assert spawn_patch.call_count == 2
+
+
+def test_get_proxy_direct_unparseable_uri_raises_value_error():
+    provider = V2Ray(servers=[])
+    provider.binary = Path("/fake/xray")
+    with pytest.raises(ValueError, match="could not be parsed"):
+        provider.get_proxy("vmess://!!!not-base64!!!")
+
+
+def test_get_proxy_country_query_still_works_alongside_direct_uri_mode():
+    """Both modes coexist: country queries use the server pool, URIs use one-shot spawn."""
+    provider = V2Ray(
+        servers=[_make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1")],
+    )
+    provider.binary = Path("/fake/xray")
+    patches = _patch_lifecycle(provider)
+    direct_uri = _make_vless_uri(remark="🇯🇵 JP", address="2.2.2.2")
+    with patches[0] as spawn_patch, patches[1], patches[2], patches[3], patches[4], patches[5]:
+        country_result = provider.get_proxy("us")
+        direct_result = provider.get_proxy(direct_uri)
+    assert country_result is not None
+    assert direct_result is not None
+    assert country_result != direct_result  # different subprocesses / ports
+    assert spawn_patch.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# resolve_proxy: v2ray: prefix routing (including the digit-in-name fix)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_proxy_routes_v2ray_prefix_to_v2ray_provider():
+    """``--proxy v2ray:us`` must route to the V2Ray provider, not fall through.
+
+    This is a regression test for the provider-prefix regex: the old ``[a-z]+``
+    pattern didn't match ``v2ray`` (because of the digit ``2``), so the query
+    silently fell through to the try-every-provider loop and raised a confusing
+    "No proxy provider had a proxy" error.
+    """
+    from unshackle.core.proxies.resolve import resolve_proxy
+
+    v2ray_provider = MagicMock()
+    v2ray_provider.__class__.__name__ = "V2Ray"
+    v2ray_provider.get_proxy.return_value = "socks5://127.0.0.1:11080"
+
+    result = resolve_proxy("v2ray:us", [v2ray_provider])
+    assert result == "socks5://127.0.0.1:11080"
+    v2ray_provider.get_proxy.assert_called_once_with("us")
+
+
+def test_resolve_proxy_routes_v2ray_vmess_uri_to_v2ray_provider():
+    """``--proxy v2ray:vmess://...`` routes the URI to the V2Ray provider."""
+    from unshackle.core.proxies.resolve import resolve_proxy
+
+    v2ray_provider = MagicMock()
+    v2ray_provider.__class__.__name__ = "V2Ray"
+    v2ray_provider.get_proxy.return_value = "socks5://127.0.0.1:11080"
+
+    uri = _make_vmess_uri(remark="🇺🇸 US", address="1.1.1.1")
+    result = resolve_proxy(f"v2ray:{uri}", [v2ray_provider])
+    assert result == "socks5://127.0.0.1:11080"
+    v2ray_provider.get_proxy.assert_called_once_with(uri)
+
+
+def test_resolve_proxy_routes_v2ray_vless_uri_to_v2ray_provider():
+    from unshackle.core.proxies.resolve import resolve_proxy
+
+    v2ray_provider = MagicMock()
+    v2ray_provider.__class__.__name__ = "V2Ray"
+    v2ray_provider.get_proxy.return_value = "socks5://127.0.0.1:11080"
+
+    uri = _make_vless_uri(remark="🇯🇵 JP", address="2.2.2.2")
+    result = resolve_proxy(f"v2ray:{uri}", [v2ray_provider])
+    assert result == "socks5://127.0.0.1:11080"
+    v2ray_provider.get_proxy.assert_called_once_with(uri)
+
+
+def test_resolve_proxy_routes_v2ray_ss_uri_to_v2ray_provider():
+    from unshackle.core.proxies.resolve import resolve_proxy
+
+    v2ray_provider = MagicMock()
+    v2ray_provider.__class__.__name__ = "V2Ray"
+    v2ray_provider.get_proxy.return_value = "socks5://127.0.0.1:11080"
+
+    uri = _make_ss_sip002_uri(remark="🇩🇪 DE", address="3.3.3.3")
+    result = resolve_proxy(f"v2ray:{uri}", [v2ray_provider])
+    assert result == "socks5://127.0.0.1:11080"
+    v2ray_provider.get_proxy.assert_called_once_with(uri)
+
+
+def test_resolve_proxy_v2ray_not_found_lists_available_providers():
+    from unshackle.core.proxies.resolve import resolve_proxy
+
+    nordvpn = MagicMock()
+    nordvpn.__class__.__name__ = "NordVPN"
+
+    with pytest.raises(ValueError, match="Proxy provider 'v2ray' not found"):
+        resolve_proxy("v2ray:us", [nordvpn])
+
+
+def test_resolve_proxy_still_routes_all_letter_provider_names():
+    """The regex fix must not break existing providers (all-letter names)."""
+    from unshackle.core.proxies.resolve import resolve_proxy
+
+    nordvpn = MagicMock()
+    nordvpn.__class__.__name__ = "NordVPN"
+    nordvpn.get_proxy.return_value = "https://user:pass@us.proxy.nordvpn.com:89"
+
+    result = resolve_proxy("nordvpn:us", [nordvpn])
+    assert "nordvpn.com" in result
+    nordvpn.get_proxy.assert_called_once_with("us")
+
+
+def test_resolve_proxy_country_only_does_not_match_v2ray_prefix():
+    """``--proxy us`` (no prefix) must NOT be routed to the V2Ray provider.
+
+    It should fall through to the try-every-provider loop so Basic / NordVPN / etc.
+    can handle the bare country code.
+    """
+    from unshackle.core.proxies.resolve import resolve_proxy
+
+    v2ray_provider = MagicMock()
+    v2ray_provider.__class__.__name__ = "V2Ray"
+    v2ray_provider.get_proxy.return_value = None  # V2Ray has no opinion on bare "us"
+
+    basic_provider = MagicMock()
+    basic_provider.__class__.__name__ = "Basic"
+    basic_provider.get_proxy.return_value = "http://us-proxy.example:8080"
+
+    result = resolve_proxy("us", [v2ray_provider, basic_provider])
+    assert result == "http://us-proxy.example:8080"
+    # Both providers are tried (V2Ray first, then Basic which matches).
+    v2ray_provider.get_proxy.assert_called_once_with("us")
+    basic_provider.get_proxy.assert_called_once_with("us")

--- a/unshackle/commands/dl.py
+++ b/unshackle/commands/dl.py
@@ -50,7 +50,8 @@ from unshackle.core.drm import DRM_T, ClearKeyCENC, MonaLisa, PlayReady, Widevin
 from unshackle.core.events import events
 from unshackle.core.music import (MusicAudioIntegrityError, MusicMetadataResult, MusicPlanner, MusicRenderer,
                                   file_md5, verify_music_audio, write_music_manifest, write_music_metadata)
-from unshackle.core.proxies import Basic, ExpressVPN, Gluetun, Hola, NordVPN, ProtonVPN, SurfsharkVPN, WindscribeVPN
+from unshackle.core.proxies import (Basic, ExpressVPN, Gluetun, Hola, NordVPN, ProtonVPN, SurfsharkVPN, V2Ray,
+                                    WindscribeVPN)
 from unshackle.core.service import Service
 from unshackle.core.services import Services
 from unshackle.core.title_cacher import get_account_hash
@@ -1062,6 +1063,11 @@ class dl:
                     self.proxy_providers.append(WindscribeVPN(**config.proxy_providers["windscribevpn"]))
                 if config.proxy_providers.get("gluetun"):
                     self.proxy_providers.append(Gluetun(**config.proxy_providers["gluetun"]))
+                # V2Ray is config-gated: a ``v2ray:`` block (even an empty one) is required
+                # to opt in. Direct-URI mode (``--proxy v2ray:vmess://...``) works with
+                # an empty ``v2ray: {}`` block.
+                if config.proxy_providers.get("v2ray") is not None:
+                    self.proxy_providers.append(V2Ray(**config.proxy_providers["v2ray"]))
                 if binaries.HolaProxy:
                     self.proxy_providers.append(Hola())
                 for proxy_provider in self.proxy_providers:
@@ -1069,15 +1075,27 @@ class dl:
 
             if proxy:
                 requested_provider = None
-                if re.match(r"^[a-z]+:.+$", proxy, re.IGNORECASE):
+                # Provider prefix is a name starting with a letter, followed by letters/digits, then ":".
+                # The digit allowance is required so provider names like "v2ray" (which contains a "2")
+                # are recognised.
+                if re.match(r"^[a-z][a-z0-9]*:.+$", proxy, re.IGNORECASE):
                     # requesting proxy from a specific proxy provider
                     requested_provider, proxy = proxy.split(":", maxsplit=1)
                 # Match simple region codes (us, ca, uk1, us:ny) or provider:region (nordvpn:ca, protonvpn:us:ny).
                 # ':' is allowed as a city separator (e.g. nordvpn:us:seattle, protonvpn:de:berlin).
-                if re.match(r"^[a-z]{2}(?:[-:][a-z0-9]+)*(?:\d+)?$", proxy, re.IGNORECASE) or re.match(
-                    r"^[a-z]+:[a-z]{2}(?:[-:][a-z0-9]+)*(?:\d+)?$", proxy, re.IGNORECASE
+                # Also accept V2Ray direct-URI queries (vmess://, vless://, trojan://, ss://) which the
+                # V2Ray provider spawns a one-shot subprocess for.
+                is_v2ray_uri = requested_provider == "v2ray" and proxy.lower().startswith(
+                    ("vmess://", "vless://", "trojan://", "ss://")
+                )
+                if (
+                    re.match(r"^[a-z]{2}(?:[-:][a-z0-9]+)*(?:\d+)?$", proxy, re.IGNORECASE)
+                    or re.match(r"^[a-z][a-z0-9]*:[a-z]{2}(?:[-:][a-z0-9]+)*(?:\d+)?$", proxy, re.IGNORECASE)
+                    or is_v2ray_uri
                 ):
-                    proxy = proxy.lower()
+                    # Don't lowercase V2Ray URIs — their base64 payloads are case-sensitive.
+                    if not is_v2ray_uri:
+                        proxy = proxy.lower()
                     # Preserve the original user query (region code) for service-specific proxy_map overrides.
                     # NOTE: `proxy` may be overwritten with the resolved proxy URI later.
                     proxy_query = proxy

--- a/unshackle/commands/env.py
+++ b/unshackle/commands/env.py
@@ -89,6 +89,8 @@ def get_dependencies() -> list[dict]:
         },
         {"name": "Caddy", "binary": binaries.Caddy, "required": False, "desc": "Web server", "cat": "Network"},
         {"name": "Docker", "binary": binaries.Docker, "required": False, "desc": "Gluetun VPN", "cat": "Network"},
+        {"name": "xray", "binary": binaries.Xray, "required": False, "desc": "V2Ray proxy", "cat": "Network"},
+        {"name": "v2ray", "binary": binaries.V2Ray, "required": False, "desc": "V2Ray proxy (fallback)", "cat": "Network"},
         {"name": "git", "binary": binaries.Git, "required": False, "desc": "Service repos", "cat": "Network"},
     ]
 

--- a/unshackle/commands/search.py
+++ b/unshackle/commands/search.py
@@ -16,7 +16,8 @@ from unshackle.core import binaries
 from unshackle.core.config import config
 from unshackle.core.console import console
 from unshackle.core.constants import context_settings
-from unshackle.core.proxies import Basic, ExpressVPN, Gluetun, Hola, NordVPN, ProtonVPN, SurfsharkVPN, WindscribeVPN
+from unshackle.core.proxies import (Basic, ExpressVPN, Gluetun, Hola, NordVPN, ProtonVPN, SurfsharkVPN, V2Ray,
+                                    WindscribeVPN)
 from unshackle.core.service import Service
 from unshackle.core.services import Services
 from unshackle.core.utils.click_types import ContextData
@@ -81,6 +82,11 @@ def search(ctx: click.Context, no_proxy: bool, profile: Optional[str] = None, pr
                 proxy_providers.append(WindscribeVPN(**config.proxy_providers["windscribevpn"]))
             if config.proxy_providers.get("gluetun"):
                 proxy_providers.append(Gluetun(**config.proxy_providers["gluetun"]))
+            # V2Ray is config-gated: a ``v2ray:`` block (even an empty one) is required
+            # to opt in. Direct-URI mode (``--proxy v2ray:vmess://...``) works with
+            # an empty ``v2ray: {}`` block.
+            if config.proxy_providers.get("v2ray") is not None:
+                proxy_providers.append(V2Ray(**config.proxy_providers["v2ray"]))
             if binaries.HolaProxy:
                 proxy_providers.append(Hola())
             for proxy_provider in proxy_providers:
@@ -88,14 +94,26 @@ def search(ctx: click.Context, no_proxy: bool, profile: Optional[str] = None, pr
 
         if proxy:
             requested_provider = None
-            if re.match(r"^[a-z]+:.+$", proxy, re.IGNORECASE):
+            # Provider prefix is a name starting with a letter, followed by letters/digits, then ":".
+            # The digit allowance is required so provider names like "v2ray" (which contains a "2")
+            # are recognised.
+            if re.match(r"^[a-z][a-z0-9]*:.+$", proxy, re.IGNORECASE):
                 # requesting proxy from a specific proxy provider
                 requested_provider, proxy = proxy.split(":", maxsplit=1)
-            # Match simple region codes (us, ca, uk1) or provider:region format (nordvpn:ca, windscribe:us)
-            if re.match(r"^[a-z]{2}(?:[-][a-z0-9]+)*(?:\d+)?$", proxy, re.IGNORECASE) or re.match(
-                r"^[a-z]+:[a-z]{2}(?:[-][a-z0-9]+)*(?:\d+)?$", proxy, re.IGNORECASE
+            # Match simple region codes (us, ca, uk1) or provider:region format (nordvpn:ca, windscribe:us).
+            # Also accept V2Ray direct-URI queries (vmess://, vless://, trojan://, ss://) which the
+            # V2Ray provider spawns a one-shot subprocess for.
+            is_v2ray_uri = requested_provider == "v2ray" and proxy.lower().startswith(
+                ("vmess://", "vless://", "trojan://", "ss://")
+            )
+            if (
+                re.match(r"^[a-z]{2}(?:[-][a-z0-9]+)*(?:\d+)?$", proxy, re.IGNORECASE)
+                or re.match(r"^[a-z][a-z0-9]*:[a-z]{2}(?:[-][a-z0-9]+)*(?:\d+)?$", proxy, re.IGNORECASE)
+                or is_v2ray_uri
             ):
-                proxy = proxy.lower()
+                # Don't lowercase V2Ray URIs — their base64 payloads are case-sensitive.
+                if not is_v2ray_uri:
+                    proxy = proxy.lower()
                 with console.status(f"Getting a Proxy to {proxy}...", spinner="dots"):
                     if requested_provider:
                         proxy_provider = next(

--- a/unshackle/core/binaries.py
+++ b/unshackle/core/binaries.py
@@ -58,6 +58,11 @@ Mp4decrypt = find("mp4decrypt")
 Docker = find("docker")
 ML_Worker = find("ML-Worker")
 Git = find("git")
+# V2Ray proxy core. Xray (https://github.com/XTLS/Xray-core) is the modern, fully-compatible
+# fork and is preferred when available; v2ray-core (https://github.com/v2fly/v2ray-core)
+# is the original and is used as a fallback. Either binary drives the V2Ray proxy provider.
+Xray = find("xray")
+V2Ray = find("v2ray")
 
 
 __all__ = (
@@ -78,5 +83,7 @@ __all__ = (
     "Docker",
     "ML_Worker",
     "Git",
+    "Xray",
+    "V2Ray",
     "find",
 )

--- a/unshackle/core/proxies/__init__.py
+++ b/unshackle/core/proxies/__init__.py
@@ -5,6 +5,17 @@ from .hola import Hola
 from .nordvpn import NordVPN
 from .proton import ProtonVPN
 from .surfsharkvpn import SurfsharkVPN
+from .v2ray import V2Ray
 from .windscribevpn import WindscribeVPN
 
-__all__ = ("Basic", "ExpressVPN", "Gluetun", "Hola", "NordVPN", "ProtonVPN", "SurfsharkVPN", "WindscribeVPN")
+__all__ = (
+    "Basic",
+    "ExpressVPN",
+    "Gluetun",
+    "Hola",
+    "NordVPN",
+    "ProtonVPN",
+    "SurfsharkVPN",
+    "V2Ray",
+    "WindscribeVPN",
+)

--- a/unshackle/core/proxies/resolve.py
+++ b/unshackle/core/proxies/resolve.py
@@ -24,6 +24,7 @@ def initialize_proxy_providers() -> List[Any]:
         from unshackle.core.proxies.nordvpn import NordVPN
         from unshackle.core.proxies.proton import ProtonVPN
         from unshackle.core.proxies.surfsharkvpn import SurfsharkVPN
+        from unshackle.core.proxies.v2ray import V2Ray
 
         proxy_config = getattr(main_config, "proxy_providers", {})
 
@@ -40,6 +41,12 @@ def initialize_proxy_providers() -> List[Any]:
             proxy_providers.append(proton)
         if proxy_config.get("surfsharkvpn"):
             proxy_providers.append(SurfsharkVPN(**proxy_config["surfsharkvpn"]))
+        # V2Ray is config-gated: a ``v2ray:`` block (even an empty one) is required to
+        # opt in. This avoids instantiating a provider for users who have xray installed
+        # for unrelated reasons. Direct-URI mode (``--proxy v2ray:vmess://...``) works
+        # with an empty ``v2ray: {}`` block.
+        if proxy_config.get("v2ray") is not None:
+            proxy_providers.append(V2Ray(**proxy_config["v2ray"]))
         if hasattr(binaries, "HolaProxy") and binaries.HolaProxy:
             proxy_providers.append(Hola())
 
@@ -62,6 +69,7 @@ def resolve_proxy(proxy: str, proxy_providers: List[Any]) -> Optional[str]:
       - Direct URI: "https://...", "socks5://..."
       - Country code: "us", "uk"
       - Provider:country: "nordvpn:us"
+      - Provider:URI: "v2ray:vmess://..." (V2Ray direct-URI mode)
     """
     if not proxy:
         return None
@@ -71,7 +79,10 @@ def resolve_proxy(proxy: str, proxy_providers: List[Any]) -> Optional[str]:
 
     requested_provider = None
     query = proxy
-    if re.match(r"^[a-z]+:.+$", proxy, re.IGNORECASE):
+    # Provider prefix is a name starting with a letter, followed by letters/digits, then ":".
+    # The digit allowance is required so provider names like "v2ray" (which contains a "2")
+    # are recognised.
+    if re.match(r"^[a-z][a-z0-9]*:.+$", proxy, re.IGNORECASE):
         requested_provider, query = proxy.split(":", maxsplit=1)
 
     if requested_provider:

--- a/unshackle/core/proxies/v2ray.py
+++ b/unshackle/core/proxies/v2ray.py
@@ -51,7 +51,8 @@ import requests
 
 from unshackle.core import binaries
 from unshackle.core.proxies.proxy import Proxy
-from unshackle.core.utilities import COUNTRY_CODE_ALIASES, get_country_code, get_country_name, log_event
+from unshackle.core.utilities import (COUNTRY_CODE_ALIASES, get_country_code, get_country_name, log_event,
+                                      timed_operation)
 from unshackle.core.utils.ip_info import get_ip_info
 from unshackle.core.utils.redact import redact_text
 
@@ -1144,21 +1145,33 @@ class V2Ray(Proxy):
             self._last_connection = process_info
 
         # Wait for the SOCKS5 inbound to accept connections.
-        if not self._wait_for_ready(socks_port, timeout=self.startup_timeout):
-            exit_output = process_info.get("exit_output", "")
-            with self._port_lock:
-                self._kill_process(process_info)
-                self._active.pop(query_key, None)
-            # Include the actual xray/v2ray stderr in the error so the user can diagnose
-            # config issues, missing dat files, bad credentials, etc.
-            detail = exit_output or "no output captured"
-            raise RuntimeError(
-                f"V2Ray subprocess failed to start (server={server.label}, port={socks_port}, "
-                f"binary={self.binary}). Subprocess output:\n{detail}"
-            )
+        with timed_operation(
+            "v2ray_wait_for_ready",
+            level="DEBUG",
+            message=f"Waiting for V2Ray subprocess on port {socks_port}",
+            context={"server": server.label, "port": socks_port},
+        ):
+            if not self._wait_for_ready(socks_port, timeout=self.startup_timeout):
+                exit_output = process_info.get("exit_output", "")
+                with self._port_lock:
+                    self._kill_process(process_info)
+                    self._active.pop(query_key, None)
+                # Include the actual xray/v2ray stderr in the error so the user can diagnose
+                # config issues, missing dat files, bad credentials, etc.
+                detail = exit_output or "no output captured"
+                raise RuntimeError(
+                    f"V2Ray subprocess failed to start (server={server.label}, port={socks_port}, "
+                    f"binary={self.binary}). Subprocess output:\n{detail}"
+                )
 
         if self.verify_ip:
-            self._verify_proxy(query_key)
+            with timed_operation(
+                "v2ray_verify_ip",
+                level="DEBUG",
+                message=f"Verifying exit IP for {server.label}",
+                context={"server": server.label, "port": socks_port},
+            ):
+                self._verify_proxy(query_key)
 
         return self._build_proxy_uri(socks_port, http_port)
 

--- a/unshackle/core/proxies/v2ray.py
+++ b/unshackle/core/proxies/v2ray.py
@@ -1,0 +1,1755 @@
+"""V2Ray/Xray proxy provider.
+
+Spins up a local V2Ray (https://www.v2fly.org/) or Xray (https://xtls.github.io/) instance
+with an ephemeral SOCKS5 / HTTP inbound on 127.0.0.1, then routes traffic through a
+user-selected outbound (VMess, VLESS, Trojan, or Shadowsocks).
+
+Servers can be supplied in four ways (all can coexist):
+
+1. ``subscription_url`` — base64/plain subscription endpoint(s).
+2. ``config_path`` — a pre-built V2Ray/Xray JSON config file.
+3. ``servers`` — inline list of ``vmess://`` / ``vless://`` / ``trojan://`` / ``ss://`` URIs.
+4. ``countries`` — ``basic``-style per-country URI assignment.
+
+A V2Ray URI can also be passed directly on the CLI (``--proxy v2ray:vmess://...``) for
+one-shot use, provided a minimal ``v2ray:`` config entry exists (even an empty one).
+
+Query format (after the ``v2ray:`` prefix):
+    v2ray:us                -- any server assigned to / detected as US
+    v2ray:us:1              -- the first US server (1-indexed, like Basic)
+    v2ray:tokyo             -- match a server by remark substring (case-insensitive)
+    v2ray:us:tokyo          -- country + remark substring
+    v2ray:stream-us         -- an alias from ``server_map`` or ``countries``
+    v2ray:vmess://...       -- spawn a one-shot subprocess for that exact URI
+
+The provider follows the same lifecycle pattern as ``Gluetun``: each unique query gets its
+own subprocess on a dedicated port, instances are reused for the rest of the process, and
+everything is torn down via an ``atexit`` handler.
+"""
+
+from __future__ import annotations
+
+import atexit
+import base64
+import json
+import logging
+import os
+import random
+import re
+import socket
+import subprocess
+import tempfile
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+from urllib.parse import parse_qs, unquote, urlparse
+
+import pycountry
+import requests
+
+from unshackle.core import binaries
+from unshackle.core.proxies.proxy import Proxy
+from unshackle.core.utilities import COUNTRY_CODE_ALIASES, get_country_code, get_country_name, log_event
+from unshackle.core.utils.ip_info import get_ip_info
+from unshackle.core.utils.redact import redact_text
+
+log = logging.getLogger("proxies.v2ray")
+
+
+def _normalise_country_code(code: str) -> Optional[str]:
+    """Lowercase ISO 3166-1 alpha-2 code, applying the project's UK -> GB alias."""
+    if not code:
+        return None
+    lowered = code.strip().lower()
+    return COUNTRY_CODE_ALIASES.get(lowered, lowered)
+
+# Module-level registry so every V2Ray instance can be cleaned up on interpreter exit,
+# mirroring the Gluetun pattern. Multiple Proxy providers may exist concurrently
+# (e.g. one in the main process, one in a serve worker) so we keep them all here.
+_v2ray_instances: list["V2Ray"] = []
+_cleanup_lock = threading.Lock()
+_cleanup_registered = False
+
+
+def _cleanup_all_v2ray_processes() -> None:
+    """Stop every spawned V2Ray/Xray subprocess on exit."""
+    with _cleanup_lock:
+        instances = list(_v2ray_instances)
+        _v2ray_instances.clear()
+    for instance in instances:
+        try:
+            instance.cleanup()
+        except Exception:
+            pass
+
+
+def _register_cleanup() -> None:
+    """Register the atexit handler exactly once."""
+    global _cleanup_registered
+    with _cleanup_lock:
+        if not _cleanup_registered:
+            atexit.register(_cleanup_all_v2ray_processes)
+            _cleanup_registered = True
+
+
+# ---------------------------------------------------------------------------
+# Server model + URI parsing
+# ---------------------------------------------------------------------------
+
+# Regex used to recover a country code from a remark/PS string. Handles flag-emoji
+# prefixes (🇺🇸), parenthesised codes, and bare 2-letter prefixes like "US-...".
+_FLAG_EMOJI_RE = re.compile(
+    "[\U0001F1E6-\U0001F1FF]{2}"  # regional indicator pair (a flag)
+)
+_COUNTRY_HINT_RE = re.compile(
+    r"(?:^|[\s\-\|_(\[])([A-Z]{2})(?:$|[\s\-\|_)\]])"
+)
+
+
+def _build_country_name_index() -> list[tuple[str, str]]:
+    """Build a (lowercase_name, alpha_2_code) index from pycountry, sorted longest-first.
+
+    Uses all three name attributes pycountry provides (``name``, ``common_name``,
+    ``official_name``) so both ISO names and common names like "South Korea" are matched.
+    Sorted by name length descending so "United States of America" matches before
+    "United States" before "United" in a substring search.
+    """
+    entries: list[tuple[str, str]] = []
+    for country in pycountry.countries:
+        for attr in ("name", "common_name", "official_name"):
+            name = getattr(country, attr, None)
+            if name:
+                entries.append((name.lower(), country.alpha_2.lower()))
+    # Deduplicate (some countries share names) and sort longest-first.
+    seen: set[str] = set()
+    unique: list[tuple[str, str]] = []
+    for name, code in entries:
+        if name not in seen:
+            seen.add(name)
+            unique.append((name, code))
+    unique.sort(key=lambda x: len(x[0]), reverse=True)
+    return unique
+
+
+# Built once at module load — covers all 249 pycountry countries with their
+# name, common_name, and official_name variants.
+_ALL_COUNTRY_NAMES = _build_country_name_index()
+
+
+@dataclass
+class V2RayServer:
+    """A single parsed outbound server."""
+
+    protocol: str  # vmess | vless | trojan | shadowsocks
+    address: str
+    port: int
+    remark: str = ""
+    # Protocol-specific fields. Kept loose (dict) so we can serialise to V2Ray JSON
+    # without having to model every protocol's quirks as a dataclass.
+    settings: dict = field(default_factory=dict)
+    # Network/stream settings (ws, tcp, grpc, h2, quic, httpupgrade)
+    network: str = "tcp"
+    stream: dict = field(default_factory=dict)
+    # Detected ISO 3166-1 alpha-2 country code (lowercase) if any.
+    country: Optional[str] = None
+
+    @property
+    def label(self) -> str:
+        """Short, human-readable identifier used for logs and __repr__."""
+        return (self.remark or f"{self.protocol}-{self.address}:{self.port}").strip()
+
+
+def _b64_decode_loose(payload: str) -> str:
+    """Decode a base64 / base64url string, padding it leniently."""
+    payload = payload.strip().replace("\n", "").replace("\r", "")
+    # v2ray-style base64url (no padding) is common
+    pad = "=" * (-len(payload) % 4)
+    try:
+        return base64.urlsafe_b64decode(payload + pad).decode("utf-8")
+    except Exception:
+        try:
+            return base64.b64decode(payload + pad).decode("utf-8")
+        except Exception as error:
+            raise ValueError(f"Could not base64-decode payload ({len(payload)} chars): {error}")
+
+
+def _detect_country(remark: str, server_name: str = "") -> Optional[str]:
+    """Heuristically infer an ISO 3166-1 alpha-2 (lowercase) country code from a remark.
+
+    Detection order:
+    1. Flag-emoji stripped, then 2-letter uppercase hints (``US``, ``JP``) — validated
+       against pycountry so false positives like ``VR`` or ``4K`` are rejected.
+    2. Full country names from pycountry (``name``, ``common_name``, ``official_name``)
+       — matched as case-insensitive substrings, longest-first so ``"United States of
+       America"`` wins over ``"United"``.
+    3. TLD of the SNI / server hostname (e.g. ``server.fr`` → ``fr``).
+
+    ``UK`` is handled implicitly: ``COUNTRY_CODE_ALIASES`` maps ``uk`` → ``gb``, so the
+    2-letter hint path catches it and returns ``gb``.
+    """
+    if not remark:
+        remark = ""
+    text = remark
+
+    # Strip flag emojis first so the surrounding text is easier to parse.
+    text = _FLAG_EMOJI_RE.sub(" ", text)
+
+    # 1. Explicit 2-letter hints like "(US)", "- US -", "US | Server 1"
+    for match in _COUNTRY_HINT_RE.finditer(text):
+        candidate = match.group(1).lower()
+        if get_country_name(candidate):
+            return _normalise_country_code(candidate)
+
+    # 2. Full country names — iterate all pycountry names, longest-first.
+    lowered = text.lower()
+    for name, code in _ALL_COUNTRY_NAMES:
+        if name in lowered:
+            return _normalise_country_code(code)
+
+    # 3. TLD of the SNI / server hostname.
+    if server_name:
+        host = server_name.split(":")[0]
+        tld = host.rsplit(".", 1)[-1].lower() if "." in host else ""
+        if len(tld) == 2 and get_country_name(tld):
+            return _normalise_country_code(tld)
+
+    return None
+
+
+def _split_url_fragment(uri: str) -> tuple[str, str]:
+    """Split a URI into (body, fragment) where fragment is URL-decoded."""
+    if "#" in uri:
+        body, frag = uri.split("#", 1)
+        return body, unquote(frag)
+    return uri, ""
+
+
+def _parse_vmess(uri: str) -> Optional[V2RayServer]:
+    """Parse a ``vmess://`` (V2Ray VMess) URI into a server record."""
+    if not uri.startswith("vmess://"):
+        return None
+    payload = uri[len("vmess://"):]
+    try:
+        data = json.loads(_b64_decode_loose(payload))
+    except (ValueError, json.JSONDecodeError) as error:
+        log.debug("skipping unparseable vmess URI: %s", error)
+        return None
+
+    address = str(data.get("add") or "").strip()
+    port_raw = data.get("port")
+    if not address or not port_raw:
+        return None
+    try:
+        port = int(port_raw)
+    except (TypeError, ValueError):
+        return None
+
+    network = str(data.get("net") or "tcp").lower()
+    tls_setting = str(data.get("tls") or "").lower()
+    security = "tls" if tls_setting in ("tls", "1", "true") else ("reality" if tls_setting == "reality" else "none")
+
+    stream: dict = {
+        "security": security,
+        "network": network,
+    }
+    if security == "tls":
+        sni = str(data.get("sni") or data.get("host") or "").strip()
+        if sni:
+            # TLS verification defaults to ON. Only disable it if the share link
+            # explicitly carries ``verify_cert: false`` — which real vmess links
+            # essentially never do, so this is intentionally opt-in.
+            tls_settings: dict = {"serverName": sni}
+            if data.get("verify_cert") is False:
+                tls_settings["allowInsecure"] = True
+            stream["tlsSettings"] = tls_settings
+    if network in ("ws", "httpupgrade"):
+        stream["wsSettings" if network == "ws" else "httpupgradeSettings"] = {
+            "path": str(data.get("path") or "/"),
+            "host": str(data.get("host") or ""),
+        }
+    elif network == "grpc":
+        stream["grpcSettings"] = {"serviceName": str(data.get("path") or "")}
+    elif network == "h2":
+        stream["httpSettings"] = {
+            "path": str(data.get("path") or "/"),
+            "host": [str(data.get("host") or "")] if data.get("host") else [],
+        }
+
+    remark = str(data.get("ps") or "")
+    server_name = stream.get("tlsSettings", {}).get("serverName", "") if security == "tls" else ""
+    return V2RayServer(
+        protocol="vmess",
+        address=address,
+        port=port,
+        remark=remark,
+        settings={
+            "id": str(data.get("id") or ""),
+            "alterId": int(data.get("aid") or 0),
+            "security": str(data.get("scy") or "auto"),
+        },
+        network=network,
+        stream=stream,
+        country=_detect_country(remark, server_name or address),
+    )
+
+
+def _parse_vless(uri: str) -> Optional[V2RayServer]:
+    """Parse a ``vless://`` URI (VLESS, used heavily by Xray + XTLS)."""
+    if not uri.startswith("vless://"):
+        return None
+    body, fragment = _split_url_fragment(uri[len("vless://"):])
+    if "@" not in body:
+        return None
+    user_part, host_part = body.split("@", 1)
+    uuid = unquote(user_part)
+    if not uuid or not host_part:
+        return None
+
+    parsed = urlparse(f"//{host_part}")
+    address = parsed.hostname or ""
+    if not address:
+        return None
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    query = parse_qs(parsed.query)
+
+    network = (query.get("type", ["tcp"])[0]).lower()
+    security = (query.get("security", ["none"])[0]).lower()
+
+    stream: dict = {"security": security, "network": network}
+    if security == "tls":
+        sni = query.get("sni", [query.get("peer", [""])[0]])[0]
+        alpn = query.get("alpn", [""])[0]
+        fp = query.get("fp", [""])[0]
+        tls_settings: dict = {"serverName": sni}
+        if alpn:
+            tls_settings["alpn"] = alpn.split(",")
+        if fp:
+            tls_settings["fingerprint"] = fp
+        if query.get("allowInsecure", ["0"])[0] in ("1", "true"):
+            tls_settings["allowInsecure"] = True
+        stream["tlsSettings"] = tls_settings
+    elif security == "reality":
+        reality_settings: dict = {
+            "serverName": query.get("sni", [""])[0],
+            "publicKey": query.get("pbk", [""])[0],
+            "shortId": query.get("sid", [""])[0],
+            "fingerprint": query.get("fp", ["chrome"])[0],
+        }
+        if query.get("spiderX", [""])[0]:
+            reality_settings["spiderX"] = query["spiderX"][0]
+        stream["realitySettings"] = reality_settings
+
+    if network == "ws":
+        stream["wsSettings"] = {
+            "path": query.get("path", ["/"])[0],
+            "host": query.get("host", [""])[0],
+        }
+    elif network == "grpc":
+        stream["grpcSettings"] = {"serviceName": query.get("serviceName", [""])[0]}
+    elif network == "tcp" and security == "tls":
+        # Xray's "tcp+tls" with XTLS Vision / Flow
+        flow = query.get("flow", [""])[0]
+        if flow:
+            stream["tcpSettings"] = {"header": {"type": "none"}}
+    elif network == "httpupgrade":
+        stream["httpupgradeSettings"] = {
+            "path": query.get("path", ["/"])[0],
+            "host": query.get("host", [""])[0],
+        }
+
+    return V2RayServer(
+        protocol="vless",
+        address=address,
+        port=port,
+        remark=fragment,
+        settings={
+            "id": uuid,
+            "encryption": query.get("encryption", ["none"])[0],
+            "flow": query.get("flow", [""])[0] or None,
+        },
+        network=network,
+        stream=stream,
+        country=_detect_country(fragment, query.get("sni", [""])[0] or address),
+    )
+
+
+def _parse_trojan(uri: str) -> Optional[V2RayServer]:
+    """Parse a ``trojan://`` URI."""
+    if not uri.startswith("trojan://"):
+        return None
+    body, fragment = _split_url_fragment(uri[len("trojan://"):])
+    if "@" not in body:
+        return None
+    password, host_part = body.split("@", 1)
+    password = unquote(password)
+    if not password or not host_part:
+        return None
+    parsed = urlparse(f"//{host_part}")
+    address = parsed.hostname or ""
+    if not address:
+        return None
+    port = parsed.port or 443
+    query = parse_qs(parsed.query)
+
+    network = (query.get("type", ["tcp"])[0]).lower()
+    security = (query.get("security", ["tls"])[0]).lower() or "tls"
+
+    stream: dict = {"security": security, "network": network}
+    sni = query.get("sni", [query.get("peer", [""])[0]])[0]
+    if security == "tls":
+        tls_settings: dict = {"serverName": sni or address}
+        if query.get("alpn", [""])[0]:
+            tls_settings["alpn"] = query["alpn"][0].split(",")
+        if query.get("allowInsecure", ["0"])[0] in ("1", "true"):
+            tls_settings["allowInsecure"] = True
+        stream["tlsSettings"] = tls_settings
+    if network == "ws":
+        stream["wsSettings"] = {
+            "path": query.get("path", ["/"])[0],
+            "host": query.get("host", [""])[0],
+        }
+    elif network == "grpc":
+        stream["grpcSettings"] = {"serviceName": query.get("serviceName", [""])[0]}
+
+    return V2RayServer(
+        protocol="trojan",
+        address=address,
+        port=port,
+        remark=fragment,
+        settings={"password": password},
+        network=network,
+        stream=stream,
+        country=_detect_country(fragment, sni or address),
+    )
+
+
+def _parse_shadowsocks(uri: str) -> Optional[V2RayServer]:
+    """Parse a ``ss://`` (Shadowsocks) URI in either the legacy or SIP002 form."""
+    if not uri.startswith("ss://"):
+        return None
+    body, fragment = _split_url_fragment(uri[len("ss://"):])
+
+    method = password = ""
+    address = port = None
+
+    if "@" in body:
+        # SIP002 form: base64(method:password)@host:port  OR  method:password@host:port
+        creds_part, host_part = body.split("@", 1)
+        if ":" in creds_part and not creds_part.startswith("%2F"):
+            # Plain-text creds (some servers ship this)
+            method, password = creds_part.split(":", 1)
+            method = unquote(method)
+            password = unquote(password)
+        else:
+            try:
+                decoded = _b64_decode_loose(creds_part)
+                if ":" in decoded:
+                    method, password = decoded.split(":", 1)
+            except ValueError:
+                return None
+        parsed = urlparse(f"//{host_part}")
+        address = parsed.hostname or ""
+        port = parsed.port
+    else:
+        # Legacy form: ss://base64(method:password@host:port)
+        try:
+            decoded = _b64_decode_loose(body)
+        except ValueError:
+            return None
+        if "@" not in decoded or ":" not in decoded:
+            return None
+        creds, host_port = decoded.rsplit("@", 1)
+        if ":" not in creds or ":" not in host_port:
+            return None
+        method, password = creds.split(":", 1)
+        host, port_str = host_port.rsplit(":", 1)
+        address = host
+        try:
+            port = int(port_str)
+        except ValueError:
+            return None
+
+    if not address or not port or not method:
+        return None
+
+    return V2RayServer(
+        protocol="shadowsocks",
+        address=address,
+        port=port,
+        remark=fragment,
+        settings={"method": method, "password": password},
+        network="tcp",
+        stream={"security": "none", "network": "tcp"},
+        country=_detect_country(fragment, address),
+    )
+
+
+_PROTOCOL_PARSERS = (
+    _parse_vmess,
+    _parse_vless,
+    _parse_trojan,
+    _parse_shadowsocks,
+)
+
+# Schemes recognised as V2Ray-family URIs. Used by _is_v2ray_uri() to detect direct-URI
+# queries on the CLI (e.g. ``--proxy v2ray:vmess://...``).
+_V2RAY_URI_SCHEMES = ("vmess://", "vless://", "trojan://", "ss://")
+
+
+def _is_v2ray_uri(text: str) -> bool:
+    """Return True if ``text`` looks like a V2Ray-family URI (vmess/vless/trojan/ss).
+
+    Used by :meth:`V2Ray.get_proxy` to detect direct-URI queries — e.g.
+    ``--proxy v2ray:vmess://...`` — and spawn a one-shot subprocess for that exact
+    server, bypassing the country/remark selection logic.
+    """
+    if not text:
+        return False
+    text = text.strip()
+    return any(text.startswith(scheme) for scheme in _V2RAY_URI_SCHEMES)
+
+
+def parse_server_uri(uri: str) -> Optional[V2RayServer]:
+    """Parse a single ``vmess://``, ``vless://``, ``trojan://``, or ``ss://`` URI.
+
+    Returns ``None`` (and logs a debug message) if the URI is not recognised or malformed.
+    Exposed publicly so the test-suite can exercise each parser without going through the
+    subscription/network layer.
+    """
+    uri = (uri or "").strip()
+    if not uri:
+        return None
+    for parser in _PROTOCOL_PARSERS:
+        try:
+            server = parser(uri)
+        except Exception as error:
+            log.debug("parser %s raised on %r: %s", parser.__name__, uri[:80], error)
+            server = None
+        if server is not None:
+            return server
+    log.debug("no parser matched URI %r", uri[:80])
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Subscription + config-file loaders
+# ---------------------------------------------------------------------------
+
+_SUBSCRIPTION_TIMEOUT = 20.0
+_SUBSCRIPTION_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36",
+    "Accept": "*/*",
+}
+
+
+def fetch_subscription(url: str, *, timeout: float = _SUBSCRIPTION_TIMEOUT) -> list[V2RayServer]:
+    """Fetch a base64/plain subscription URL and return the parsed server list.
+
+    Subscription endpoints customarily return either a base64 blob of newline-separated
+    URIs or the URIs themselves (one per line). Both shapes are handled here, and any
+    line that fails to parse is skipped with a debug log so a single bad entry never
+    aborts the whole subscription.
+    """
+    response = requests.get(url, headers=_SUBSCRIPTION_HEADERS, timeout=timeout)
+    response.raise_for_status()
+    body = response.text.strip()
+    if not body:
+        return []
+
+    # If the body doesn't contain a recognised scheme, assume it's base64-encoded.
+    if not re.search(r"(vmess|vless|trojan|ss)://", body, re.IGNORECASE):
+        try:
+            body = _b64_decode_loose(body)
+        except ValueError as error:
+            log.warning("subscription %s looked base64 but could not be decoded: %s", url, error)
+            return []
+
+    servers: list[V2RayServer] = []
+    for raw_line in body.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        server = parse_server_uri(line)
+        if server is not None:
+            servers.append(server)
+    log.info("subscription %s yielded %d server(s)", url, len(servers))
+    return servers
+
+
+def load_config_file(path: Path) -> list[V2RayServer]:
+    """Extract outbound servers from a pre-built V2Ray/Xray JSON config file.
+
+    The file is parsed for ``outbounds`` whose protocol is one of vmess/vless/trojan/
+    shadowsocks. Each one is rebuilt as a :class:`V2RayServer` so it can take part in the
+    same query/selection logic as subscription- or inline-defined servers.
+    """
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"could not read config file {path}: {error}")
+
+    if "outbounds" not in data or not isinstance(data.get("outbounds"), list):
+        raise ValueError(f"config file {path} has no 'outbounds' list")
+    outbounds = data["outbounds"]
+
+    servers: list[V2RayServer] = []
+    for entry in outbounds:
+        if not isinstance(entry, dict):
+            continue
+        protocol = str(entry.get("protocol") or "").lower()
+        if protocol not in ("vmess", "vless", "trojan", "shadowsocks"):
+            continue
+        settings = entry.get("settings") or {}
+        stream = entry.get("streamSettings") or {}
+        servers_v2 = settings.get("vnext") or []
+        servers_ss = settings.get("servers") or []
+        if protocol in ("vmess", "vless") and servers_v2:
+            target = servers_v2[0]
+            address = str(target.get("address") or "")
+            port = int(target.get("port") or 0)
+            users = target.get("users") or [{}]
+            user = users[0] if users else {}
+            settings_flat: dict[str, Any] = {"id": str(user.get("id") or "")}
+            if protocol == "vmess":
+                settings_flat["alterId"] = int(user.get("alterId") or 0)
+                settings_flat["security"] = str(user.get("security") or "auto")
+            else:
+                settings_flat["encryption"] = str(user.get("encryption") or "none")
+                if user.get("flow"):
+                    settings_flat["flow"] = str(user.get("flow"))
+        elif protocol == "trojan" and servers_ss:
+            target = servers_ss[0]
+            address = str(target.get("address") or "")
+            port = int(target.get("port") or 0)
+            settings_flat = {"password": str(target.get("password") or "")}
+        elif protocol == "shadowsocks" and servers_ss:
+            target = servers_ss[0]
+            address = str(target.get("address") or "")
+            port = int(target.get("port") or 0)
+            settings_flat = {
+                "method": str(target.get("method") or ""),
+                "password": str(target.get("password") or ""),
+            }
+        else:
+            continue
+
+        if not address or not port:
+            continue
+        remark = str(entry.get("tag") or entry.get("remark") or "")
+        sni = ""
+        if isinstance(stream.get("tlsSettings"), dict):
+            sni = str(stream["tlsSettings"].get("serverName") or "")
+        elif isinstance(stream.get("realitySettings"), dict):
+            sni = str(stream["realitySettings"].get("serverName") or "")
+        servers.append(
+            V2RayServer(
+                protocol=protocol,
+                address=address,
+                port=port,
+                remark=remark,
+                settings=settings_flat,
+                network=str(stream.get("network") or "tcp"),
+                stream=stream or {"network": "tcp", "security": "none"},
+                country=_detect_country(remark, sni or address),
+            )
+        )
+
+    log.info("config file %s yielded %d server(s)", path, len(servers))
+    return servers
+
+
+# ---------------------------------------------------------------------------
+# V2Ray config builder
+# ---------------------------------------------------------------------------
+
+def build_outbound(server: V2RayServer, tag: str = "proxy") -> dict:
+    """Build a single V2Ray/Xray outbound dict for the given server."""
+    if server.protocol == "vmess":
+        outbound = {
+            "tag": tag,
+            "protocol": "vmess",
+            "settings": {
+                "vnext": [
+                    {
+                        "address": server.address,
+                        "port": server.port,
+                        "users": [
+                            {
+                                "id": server.settings.get("id", ""),
+                                "alterId": int(server.settings.get("alterId") or 0),
+                                "security": server.settings.get("security", "auto"),
+                            }
+                        ],
+                    }
+                ]
+            },
+            "streamSettings": _normalise_stream(server),
+        }
+    elif server.protocol == "vless":
+        user: dict = {"id": server.settings.get("id", ""), "encryption": server.settings.get("encryption", "none")}
+        if server.settings.get("flow"):
+            user["flow"] = server.settings["flow"]
+        outbound = {
+            "tag": tag,
+            "protocol": "vless",
+            "settings": {
+                "vnext": [{"address": server.address, "port": server.port, "users": [user]}]
+            },
+            "streamSettings": _normalise_stream(server),
+        }
+    elif server.protocol == "trojan":
+        outbound = {
+            "tag": tag,
+            "protocol": "trojan",
+            "settings": {
+                "servers": [
+                    {
+                        "address": server.address,
+                        "port": server.port,
+                        "password": server.settings.get("password", ""),
+                    }
+                ]
+            },
+            "streamSettings": _normalise_stream(server),
+        }
+    elif server.protocol == "shadowsocks":
+        outbound = {
+            "tag": tag,
+            "protocol": "shadowsocks",
+            "settings": {
+                "servers": [
+                    {
+                        "address": server.address,
+                        "port": server.port,
+                        "method": server.settings.get("method", ""),
+                        "password": server.settings.get("password", ""),
+                    }
+                ]
+            },
+            "streamSettings": _normalise_stream(server),
+        }
+    else:
+        raise ValueError(f"Unsupported V2Ray protocol: {server.protocol!r}")
+
+    return outbound
+
+
+def _normalise_stream(server: V2RayServer) -> dict:
+    """Return a streamSettings dict suitable for the V2Ray/Xray JSON config."""
+    stream = dict(server.stream or {})
+    stream.setdefault("network", server.network or "tcp")
+    stream.setdefault("security", "none")
+    # V2Ray expects "tcpSettings" etc. for per-transport settings; we already store
+    # them under those keys in the parser, so just copy through.
+    return stream
+
+
+def build_config(
+    server: V2RayServer,
+    *,
+    socks_port: int,
+    http_port: Optional[int] = None,
+    bind_host: str = "127.0.0.1",
+) -> dict:
+    """Build the full V2Ray/Xray JSON config for a single outbound + local inbounds.
+
+    ``bind_host`` controls the listen address for both inbounds — it must match the host
+    the readiness check connects to, otherwise ``_wait_for_ready`` will always fail.
+    """
+    inbounds: list[dict] = [
+        {
+            "tag": "socks-in",
+            "listen": bind_host,
+            "port": socks_port,
+            "protocol": "socks",
+            "settings": {"auth": "noauth", "udp": True},
+            "sniffing": {"enabled": True, "destOverride": ["http", "tls"]},
+        }
+    ]
+    if http_port:
+        inbounds.append(
+            {
+                "tag": "http-in",
+                "listen": bind_host,
+                "port": http_port,
+                "protocol": "http",
+                "sniffing": {"enabled": True, "destOverride": ["http", "tls"]},
+            }
+        )
+
+    return {
+        "log": {"loglevel": "warning"},
+        "inbounds": inbounds,
+        "outbounds": [
+            build_outbound(server, tag="proxy"),
+            {"tag": "direct", "protocol": "freedom", "settings": {}},
+            {"tag": "block", "protocol": "blackhole", "settings": {}},
+        ],
+        # Route private-IP traffic directly (bypass the proxy) using explicit CIDR ranges
+        # instead of "geoip:private" — the latter requires a geoip.dat file that is often
+        # missing from manual Xray/V2Ray installs and causes a startup crash.
+        "routing": {
+            "rules": [
+                {
+                    "type": "field",
+                    "ip": [
+                        "127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12",
+                        "192.168.0.0/16", "169.254.0.0/16", "::1/128", "fc00::/7",
+                    ],
+                    "outboundTag": "direct",
+                },
+            ]
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+class V2Ray(Proxy):
+    """V2Ray / Xray local proxy provider.
+
+    Servers may be provided in four ways (all can coexist — see the module docstring for
+    details): ``subscription_url``, ``config_path``, ``servers``, and ``countries``.
+
+    Optional ``server_map`` (dict[str, str]) lets the user override the country/alias
+    used for selection: keys are matched (case-insensitive) against either an explicit
+    alias or the server's remark substring, and the value replaces the query used to
+    reach that server. This is handy when a subscription's remarks don't include a
+    country code or use non-standard naming.
+
+    Query format (after the ``v2ray:`` prefix):
+      - ``us``         any server assigned to / detected as US
+      - ``us:1``       first US server (1-indexed)
+      - ``tokyo``      server whose remark contains "tokyo" (case-insensitive)
+      - ``us:tokyo``   US server whose remark contains "tokyo"
+      - ``stream-us``  an alias from ``server_map`` or ``countries``
+      - ``vmess://...`` spawn a one-shot subprocess for that exact URI
+
+    The provider spawns the ``xray`` binary (preferred) or falls back to ``v2ray``. Each
+    unique query gets its own subprocess on a dedicated local port; the SOCKS5 proxy URI
+    is returned. Processes are reused for the rest of the process and cleaned up on exit.
+    """
+
+    DEFAULT_VERIFY_IP = True
+    DEFAULT_STARTUP_TIMEOUT = 30.0  # seconds
+
+    def __init__(
+        self,
+        subscription_url: Optional[Any] = None,
+        config_path: Optional[Any] = None,
+        servers: Optional[list[Any]] = None,
+        countries: Optional[dict[str, Any]] = None,
+        server_map: Optional[dict[str, str]] = None,
+        binary: Optional[Any] = None,
+        bind_host: str = "127.0.0.1",
+        base_port: int = 11080,
+        proxy_scheme: str = "socks5",
+        verify_ip: bool = DEFAULT_VERIFY_IP,
+        startup_timeout: float = DEFAULT_STARTUP_TIMEOUT,
+        auto_cleanup: bool = True,
+        **kwargs: Any,
+    ):
+        """Initialise the V2Ray provider.
+
+        Args:
+            subscription_url: A single subscription URL or a list of URLs. Each is
+                fetched lazily on first ``get_proxy`` call (not at init time) so it
+                doesn't block CLI startup.
+            config_path: Path to a V2Ray/Xray JSON config file. Outbounds with known
+                protocols are extracted and added to the selectable server pool.
+            servers: Inline list of ``vmess://``/``vless://``/``trojan://``/``ss://``
+                URIs or pre-parsed server dicts (useful for tests / programmatic use).
+            countries: ``basic``-style per-country assignment — a dict mapping a country
+                code (or arbitrary alias) to a single URI string or a list of URI strings.
+                Queries like ``v2ray:us`` then pick from the URIs assigned to ``us``
+                (random pick by default; ``v2ray:us:2`` selects the second one). This is
+                the simplest way to pin specific servers to specific regions without
+                dealing with subscription URLs or remark substrings. URIs that fail to
+                parse are skipped with a warning, so a single bad entry never aborts the
+                whole map.
+            server_map: Optional dict mapping a query alias (e.g. ``"stream-us"``) to
+                either a country code, a remark substring, or a ``country:remark`` pair.
+                Lets users give friendly names to specific servers.
+            binary: Optional path to the V2Ray/Xray binary. Defaults to auto-discovery
+                via :mod:`unshackle.core.binaries` (Xray preferred, v2ray fallback).
+            bind_host: Host the local inbounds listen on (default ``127.0.0.1`` —
+                proxies are never exposed publicly by default).
+            base_port: First port to try when allocating local inbounds (default 11080).
+                Each query gets ``base_port + 2N`` (SOCKS) and ``base_port + 2N + 1``
+                (HTTP) for its inbounds.
+            proxy_scheme: Scheme used for the returned proxy URI. ``socks5`` (default)
+                and ``socks5h`` are supported; ``http`` returns the HTTP inbound URI
+                instead (requires the HTTP inbound to be enabled, which it is by default).
+            verify_ip: When True (default), verify the exit IP / country of the spawned
+                proxy via :func:`unshackle.core.utils.ip_info.get_ip_info` before
+                returning it to the caller.
+            startup_timeout: Seconds to wait for the V2Ray subprocess to start accepting
+                connections (default 30s).
+            auto_cleanup: When True (default), the subprocess is killed on object
+                destruction / interpreter exit.
+        """
+        # Resolve the binary first; the rest of init can proceed even without one (so
+        # the constructor doesn't raise during config validation in tests), but
+        # ``get_proxy`` will refuse to run without a usable binary.
+        self.binary = self._resolve_binary(binary)
+        self.bind_host = bind_host
+        self.base_port = int(base_port)
+        self.proxy_scheme = str(proxy_scheme or "socks5").lower()
+        if self.proxy_scheme not in ("socks5", "socks5h", "http", "https"):
+            raise ValueError(
+                f"proxy_scheme must be one of socks5/socks5h/http/https, got {self.proxy_scheme!r}"
+            )
+        self.verify_ip = bool(verify_ip)
+        self.startup_timeout = float(startup_timeout)
+        self.auto_cleanup = bool(auto_cleanup)
+
+        self.server_map = self._normalise_server_map(server_map or {})
+
+        # Stash the subscription URLs for lazy loading on first get_proxy() call.
+        # This avoids blocking CLI startup with (potentially slow) subscription fetches.
+        # Inline servers, config_path, and countries are loaded eagerly in __init__
+        # because they're local data (no network).
+        self._subscription_urls: list[str] = []
+        if subscription_url:
+            if isinstance(subscription_url, (list, tuple)):
+                self._subscription_urls.extend(str(u) for u in subscription_url if u)
+            else:
+                self._subscription_urls.append(str(subscription_url))
+        self._subscriptions_loaded = False
+        self._sub_load_lock = threading.Lock()
+
+        # Per-instance state
+        self._port_lock = threading.Lock()
+        self._servers: list[V2RayServer] = []
+        self._country_servers: dict[str, list[V2RayServer]] = {}
+        self._active: dict[str, dict] = {}  # query_key -> process info
+        self._last_connection: Optional[dict] = None  # info about the most recent spawn
+
+        # Each instance gets its own temp dir for config files, created on first spawn.
+        # This avoids symlink-plant attacks and clobbering between concurrent instances.
+        self._config_dir: Optional[Path] = None
+
+        # Eagerly load local server sources (inline servers, config file, countries map).
+        # Subscription URLs are deferred to first get_proxy() call.
+        self._servers = self._load_local_servers(config_path, servers)
+        self._country_servers = self._load_country_map(countries or {})
+
+        # Register for atexit cleanup (always, even if no servers loaded yet —
+        # get_proxy may load more later via direct URI queries).
+        _register_cleanup()
+        with _cleanup_lock:
+            _v2ray_instances.append(self)
+
+        log_event(
+            "v2ray_init",
+            level="INFO",
+            message="V2Ray proxy provider initialized",
+            context={
+                "binary": str(self.binary) if self.binary else None,
+                "bind_host": self.bind_host,
+                "base_port": self.base_port,
+                "proxy_scheme": self.proxy_scheme,
+                "verify_ip": self.verify_ip,
+                "server_count": len(self._servers),
+                "country_server_count": sum(len(v) for v in self._country_servers.values()),
+                "country_keys": list(self._country_servers.keys()),
+                "has_subscription": bool(self._subscription_urls),
+            },
+        )
+
+    # -- Server loading ----------------------------------------------------
+
+    def _load_local_servers(
+        self,
+        config_path: Optional[Any],
+        servers: Optional[list[Any]],
+    ) -> list[V2RayServer]:
+        """Load servers from local sources (config file + inline list) at init time.
+
+        Subscription URLs are NOT loaded here — they're deferred to first ``get_proxy()``
+        call via :meth:`_ensure_subscriptions_loaded` to avoid blocking CLI startup.
+        """
+        loaded: list[V2RayServer] = []
+
+        # 1. Config file
+        if config_path:
+            path = Path(config_path).expanduser()
+            if not path.is_file():
+                log.warning("config_path %s does not exist", path)
+            else:
+                try:
+                    loaded.extend(load_config_file(path))
+                except Exception as error:
+                    log.warning("config file %s failed: %s", path, error)
+
+        # 2. Inline servers
+        if servers:
+            for entry in servers:
+                if isinstance(entry, str):
+                    parsed = parse_server_uri(entry)
+                    if parsed is not None:
+                        loaded.append(parsed)
+                elif isinstance(entry, dict):
+                    # Accept a pre-parsed server dict (useful for tests / programmatic use).
+                    try:
+                        loaded.append(V2RayServer(**entry))
+                    except TypeError as error:
+                        log.warning("skipping malformed inline server dict: %s", error)
+
+        # De-duplicate by (protocol, address, port) — many subscriptions list the same
+        # server under multiple remarks.
+        seen: set[tuple[str, str, int]] = set()
+        unique: list[V2RayServer] = []
+        for s in loaded:
+            key = (s.protocol, s.address.lower(), s.port)
+            if key in seen:
+                continue
+            seen.add(key)
+            unique.append(s)
+        return unique
+
+    def _ensure_subscriptions_loaded(self) -> None:
+        """Lazily fetch subscription URLs on first get_proxy() call.
+
+        This defers the (potentially slow, up to 20s per URL) subscription fetch out of
+        ``__init__`` so CLI startup isn't blocked. Thread-safe via _sub_load_lock.
+        """
+        if self._subscriptions_loaded or not self._subscription_urls:
+            return
+        with self._sub_load_lock:
+            if self._subscriptions_loaded:  # double-checked locking
+                return
+            for url in self._subscription_urls:
+                try:
+                    new_servers = fetch_subscription(url)
+                    # De-duplicate against existing servers
+                    seen = {(s.protocol, s.address.lower(), s.port) for s in self._servers}
+                    for s in new_servers:
+                        key = (s.protocol, s.address.lower(), s.port)
+                        if key not in seen:
+                            self._servers.append(s)
+                            seen.add(key)
+                except Exception as error:
+                    log.warning("subscription %s failed: %s", redact_text(url), error)
+            self._subscriptions_loaded = True
+
+    # -- Proxy interface ---------------------------------------------------
+
+    def __repr__(self) -> str:
+        flat_countries = {s.country for s in self._servers if s.country}
+        mapped_countries = set(self._country_servers.keys())
+        all_countries = flat_countries | mapped_countries
+        total_servers = len(self._servers) + sum(len(v) for v in self._country_servers.values())
+        countries = len(all_countries)
+        return f"{countries} Countr{['ies', 'y'][countries == 1]} ({total_servers} Server{['s', ''][total_servers == 1]})"
+
+    def get_proxy(self, query: str) -> Optional[str]:
+        """Resolve ``query`` to a local proxy URI backed by a V2Ray subprocess.
+
+        ``query`` may be:
+
+        - A direct V2Ray URI (``vmess://...``, ``vless://...``, ``trojan://...``,
+          ``ss://...``) — a one-shot subprocess is spawned for that exact server.
+          Useful for ad-hoc invocations like ``--proxy v2ray:vmess://...``.
+        - A country code, ``country:index``, ``country:remark``, remark substring, or
+          ``server_map`` alias — resolved against the configured server pool
+          (``countries`` map first, then the flat ``servers`` / ``subscription_url`` /
+          ``config_path`` list).
+        """
+        if not self.binary:
+            raise EnvironmentError(
+                "V2Ray/Xray binary not found. Install xray (https://github.com/XTLS/Xray-core) "
+                "or v2ray (https://github.com/v2fly/v2ray-core) and ensure it is on your PATH, "
+                "or set proxy_providers.v2ray.binary in your config."
+            )
+
+        raw_query = query or ""
+        query_key = raw_query.strip().lower()
+        if not query_key:
+            raise ValueError("empty query — supply a country code, alias, remark substring, or V2Ray URI")
+
+        # Direct-URI mode: the query is itself a vmess:// / vless:// / trojan:// / ss:// URI.
+        # Parse it on the fly and spawn a one-shot subprocess. This works even when no
+        # servers are configured in YAML — handy for ``--proxy v2ray:vmess://...``.
+        if _is_v2ray_uri(raw_query):
+            server = parse_server_uri(raw_query)
+            if server is None:
+                raise ValueError(
+                    f"query looked like a V2Ray URI but could not be parsed: {redact_text(raw_query)}"
+                )
+            return self._spawn_for_server(server, query_key)
+
+        # Country / remark / alias mode — lazily fetch subscriptions on first use.
+        self._ensure_subscriptions_loaded()
+
+        if not self._servers and not self._country_servers:
+            raise ValueError(
+                "V2Ray proxy provider has no servers configured. Provide subscription_url, "
+                "config_path, servers, or countries under proxy_providers.v2ray — "
+                "or pass a vmess:// / vless:// / trojan:// / ss:// URI directly on the CLI."
+            )
+
+        # Reuse a running subprocess for the same query.
+        with self._port_lock:
+            if query_key in self._active and self._is_process_alive(self._active[query_key]):
+                entry = self._active[query_key]
+            else:
+                entry = None
+        if entry:
+            if self.verify_ip and not entry.get("verified"):
+                self._verify_proxy(query_key)
+            return self._build_proxy_uri(entry["socks_port"], entry["http_port"])
+
+        server = self._select_server(query_key)
+        if server is None:
+            # No server matched — return None to indicate "accepted but unavailable" per Proxy contract.
+            return None
+
+        return self._spawn_for_server(server, query_key)
+
+    def _spawn_for_server(self, server: V2RayServer, query_key: str) -> str:
+        """Allocate ports, spawn the subprocess for ``server``, and return the proxy URI.
+
+        Used by both the country/remark selection path and the direct-URI path so the
+        readiness / verify / cleanup behaviour is identical. Thread-safe: holds
+        ``_port_lock`` across the allocate-spawn-store sequence so concurrent calls for
+        the same key don't orphan subprocesses.
+        """
+        with self._port_lock:
+            # Re-check under the lock: another thread may have spawned this exact server
+            # while we were waiting. If so, reuse it and kill nothing.
+            if query_key in self._active and self._is_process_alive(self._active[query_key]):
+                entry = self._active[query_key]
+                if self.verify_ip and not entry.get("verified"):
+                    self._verify_proxy(query_key)
+                return self._build_proxy_uri(entry["socks_port"], entry["http_port"])
+
+            # If there's a dead entry for this key, clean it up before spawning a new one.
+            old = self._active.pop(query_key, None)
+            if old:
+                self._kill_process(old)
+
+            socks_port, http_port = self._allocate_ports()
+            config = build_config(server, socks_port=socks_port, http_port=http_port, bind_host=self.bind_host)
+            process_info = self._spawn_process(config, socks_port, http_port, server)
+            process_info["server"] = server
+            process_info["query"] = query_key
+            self._active[query_key] = process_info
+            self._last_connection = process_info
+
+        # Wait for the SOCKS5 inbound to accept connections.
+        if not self._wait_for_ready(socks_port, timeout=self.startup_timeout):
+            exit_output = process_info.get("exit_output", "")
+            with self._port_lock:
+                self._kill_process(process_info)
+                self._active.pop(query_key, None)
+            # Include the actual xray/v2ray stderr in the error so the user can diagnose
+            # config issues, missing dat files, bad credentials, etc.
+            detail = exit_output or "no output captured"
+            raise RuntimeError(
+                f"V2Ray subprocess failed to start (server={server.label}, port={socks_port}, "
+                f"binary={self.binary}). Subprocess output:\n{detail}"
+            )
+
+        if self.verify_ip:
+            self._verify_proxy(query_key)
+
+        return self._build_proxy_uri(socks_port, http_port)
+
+    # -- Server selection --------------------------------------------------
+
+    def _select_server(self, query: str) -> Optional[V2RayServer]:
+        """Pick a server matching ``query`` (already lowercased).
+
+        Selection order:
+
+        1. ``server_map`` alias (if the query matches a key).
+        2. The ``countries`` map — by ISO country code (normalised), then by the raw
+           head token (so arbitrary aliases like ``"stream-us"`` work).
+        3. The flat server list (``subscription_url`` / ``config_path`` / ``servers``),
+           filtered by country and/or remark substring.
+
+        Query grammar::
+
+            <country>              any server in that country
+            <country>:<index>      the Nth server in the country pool (1-indexed)
+            <country>:<remark>     country-filtered remark substring match
+            <remark>               remark substring match across all servers
+            <index>                the Nth server overall (1-indexed)
+            <alias>                a key from ``countries`` or ``server_map``
+        """
+        # Apply server_map aliases first.
+        mapped = self.server_map.get(query)
+        if mapped:
+            query = mapped.lower()
+
+        # Split "head:tail" — head is a country code / alias, tail is an index or remark.
+        head = query
+        tail = ""
+        if ":" in query:
+            head, tail = query.split(":", 1)
+            head = head.strip()
+            tail = tail.strip()
+
+        index: Optional[int] = None
+        remark_query: Optional[str] = None
+        if tail:
+            if tail.isdigit():
+                index = int(tail)
+            else:
+                remark_query = tail
+        elif query.isdigit():
+            # No colon but all digits — treat as a global index into the flat list.
+            index = int(query)
+
+        # Normalise head to a country code if it parses as one.
+        country: Optional[str] = None
+        if head and not head.isdigit():
+            country = self._normalise_country(head)
+
+        # If head didn't parse as a country AND isn't a known countries-map alias, treat
+        # the whole query as a remark substring. This makes "tokyo" match a server whose
+        # remark contains "tokyo", while still returning None for unknown 2-letter codes
+        # like "zz" (instead of falling through to "return the first server in the list").
+        if head and country is None and remark_query is None and index is None:
+            if head not in self._country_servers:
+                remark_query = query
+
+        # 1. Check the explicit ``countries`` map first (basic-style assignment). The map
+        # key may be either an ISO country code (e.g. "us") or an arbitrary alias (e.g.
+        # "stream-us"), so we look it up by every plausible form of the head.
+        for key in self._country_lookup_keys(country, head, query):
+            mapped_pool = self._country_servers.get(key)
+            if not mapped_pool:
+                continue
+            pool = mapped_pool
+            if remark_query:
+                pool = [s for s in pool if remark_query in (s.remark or "").lower()]
+                if not pool:
+                    log.warning(
+                        "countries[%s] has no server matching remark %r",
+                        key, remark_query,
+                    )
+                    return None
+            # The countries map uses random pick to match Basic's behaviour for
+            # multi-server lists; the flat-list fallback below uses first-match.
+            return self._pick_from_pool(pool, index, random_pick=True)
+
+        # 2. Fall back to the flat server list (subscription / config_path / servers).
+        pool = self._servers
+        if country:
+            pool = [s for s in pool if (s.country or "").lower() == country]
+        if remark_query:
+            pool = [s for s in pool if remark_query in (s.remark or "").lower()]
+
+        if not pool:
+            log.warning(
+                "no server matched query %r (country=%s, remark=%s, index=%s)",
+                query, country, remark_query, index,
+            )
+            return None
+
+        return self._pick_from_pool(pool, index, random_pick=False)
+
+    @staticmethod
+    def _country_lookup_keys(country: Optional[str], head: str, query: str) -> list[str]:
+        """Build the ordered list of keys to try against the ``countries`` map."""
+        keys: list[str] = []
+        if country:
+            keys.append(country)
+        if head:
+            keys.append(head)
+        if not head and query:
+            keys.append(query)
+        return keys
+
+    @staticmethod
+    def _pick_from_pool(
+        pool: list[V2RayServer], index: Optional[int], *, random_pick: bool = False
+    ) -> Optional[V2RayServer]:
+        """Pick a server from ``pool``, honouring the 1-indexed ``index`` if set.
+
+        When ``index`` is None and ``random_pick`` is True, a random server is chosen
+        (matching :class:`unshackle.core.proxies.basic.Basic`'s behaviour for multi-server
+        lists). Otherwise the first server is returned deterministically (preserving the
+        flat-list behaviour for subscription / inline servers).
+        """
+        if index is not None:
+            if index < 1 or index > len(pool):
+                log.warning("index %d out of range for pool of %d server(s)", index, len(pool))
+                return None
+            return pool[index - 1]
+        if random_pick:
+            return random.choice(pool)
+        return pool[0]
+
+    @staticmethod
+    def _normalise_country(token: str) -> Optional[str]:
+        """Normalise a country code or full name to a lowercase ISO 3166-1 alpha-2 code.
+
+        For 2-letter tokens, an exact alpha-2 lookup is used (with the project's UK -> GB
+        alias applied) — pycountry's fuzzy search would happily map ``"zz"`` to ``"Italy"``,
+        which is misleading. For longer tokens, fuzzy matching against full country names
+        is allowed.
+        """
+        token = token.strip().lower()
+        if not token:
+            return None
+        if len(token) == 2:
+            return _normalise_country_code(token) if get_country_name(token) else None
+        code = get_country_code(token)
+        return code.lower() if code else None
+
+    @staticmethod
+    def _normalise_server_map(server_map: dict) -> dict[str, str]:
+        return {str(k).strip().lower(): str(v).strip() for k, v in server_map.items() if k and v}
+
+    # -- Server loading ----------------------------------------------------
+
+    def _load_country_map(self, countries: dict) -> dict[str, list[V2RayServer]]:
+        """Parse the ``basic``-style ``countries`` config map.
+
+        The input is a dict mapping a country code (or arbitrary alias) to either a
+        single URI string or a list of URI strings. Each URI is parsed via
+        :func:`parse_server_uri`; entries that fail to parse are skipped with a warning
+        so a single bad URI never aborts the whole map. The returned dict maps each
+        lowercased key to the list of successfully-parsed servers.
+
+        This mirrors :class:`unshackle.core.proxies.basic.Basic` — the user explicitly
+        asked for V2Ray to support the same per-country assignment pattern.
+        """
+        if not isinstance(countries, dict):
+            raise TypeError(
+                f"'countries' must be a dict mapping country code -> URI or list of URIs, "
+                f"got {type(countries).__name__}"
+            )
+
+        result: dict[str, list[V2RayServer]] = {}
+        for raw_key, raw_value in countries.items():
+            key = str(raw_key).strip().lower()
+            if not key:
+                continue
+
+            # Normalise the value to a list of URI strings.
+            if isinstance(raw_value, str):
+                uri_list: list[str] = [raw_value]
+            elif isinstance(raw_value, (list, tuple)):
+                uri_list = [str(v) for v in raw_value if v]
+            else:
+                log.warning(
+                    "countries[%s] has unsupported value type %s — expected str or list, skipping",
+                    key, type(raw_value).__name__,
+                )
+                continue
+
+            servers: list[V2RayServer] = []
+            for uri in uri_list:
+                parsed = parse_server_uri(uri)
+                if parsed is None:
+                    log.warning("countries[%s] could not parse URI %r — skipping", key, redact_text(uri))
+                    continue
+                # Force the server's country to match the map key, so the IP-verification
+                # step (when enabled) compares against the user's intent rather than the
+                # auto-detected country from the remark.
+                if key and get_country_name(key):
+                    parsed.country = _normalise_country_code(key)
+                servers.append(parsed)
+
+            if servers:
+                result[key] = servers
+            else:
+                log.warning("countries[%s] produced zero valid servers", key)
+
+        return result
+
+    # -- Binary discovery --------------------------------------------------
+
+    @staticmethod
+    def _resolve_binary(explicit: Any) -> Optional[Path]:
+        if explicit:
+            path = Path(explicit).expanduser()
+            if not path.is_file():
+                raise FileNotFoundError(f"configured binary not found at {path}")
+            return path
+        # Xray is the modern, fully-compatible fork; prefer it when both are installed.
+        return binaries.Xray or binaries.V2Ray
+
+    # -- Process management ------------------------------------------------
+
+    def _allocate_ports(self) -> tuple[int, int]:
+        """Pick the next free (socks_port, http_port) pair.
+
+        Must be called while holding ``_port_lock``. SOCKS ports are tried at
+        ``base_port + 2N`` and the HTTP inbound at ``base_port + 2N + 1``, so each
+        subprocess gets a dedicated non-overlapping pair.
+        """
+        used = {info["socks_port"] for info in self._active.values()}
+        used |= {info["http_port"] for info in self._active.values() if info.get("http_port")}
+        socks_port = self.base_port
+        while True:
+            # Find a free SOCKS port on an even stride.
+            while socks_port in used or self._is_port_in_use(socks_port):
+                socks_port += 2
+            http_port = socks_port + 1
+            # If the HTTP port is taken, bump the SOCKS port and retry.
+            if http_port in used or self._is_port_in_use(http_port):
+                socks_port += 2
+                continue
+            return socks_port, http_port
+
+    @staticmethod
+    def _is_port_in_use(port: int) -> bool:
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind(("127.0.0.1", port))
+        except OSError:
+            return True
+        return False
+
+    def _ensure_config_dir(self) -> Path:
+        """Create a per-instance temp dir for config files (lazy, thread-safe).
+
+        Uses ``tempfile.mkdtemp`` so each V2Ray instance gets its own directory with an
+        unpredictable name — avoiding symlink-plant attacks and clobbering between
+        concurrent unshackle processes that might share the same base port.
+        """
+        if self._config_dir is None or not self._config_dir.is_dir():
+            self._config_dir = Path(tempfile.mkdtemp(prefix="unshackle-v2ray-"))
+        return self._config_dir
+
+    def _spawn_process(
+        self,
+        config: dict,
+        socks_port: int,
+        http_port: int,
+        server: V2RayServer,
+    ) -> dict:
+        """Write the config to a temp file and start the V2Ray/Xray subprocess.
+
+        The config file is created with ``O_EXCL`` to prevent symlink-plant attacks,
+        and written with ``0600`` permissions since it contains server credentials.
+        stdout/stderr go to ``DEVNULL`` to avoid pipe-buffer deadlocks during long
+        downloads — the subprocess's exit output is captured separately via
+        ``communicate()`` when a readiness check fails.
+        """
+        config_dir = self._ensure_config_dir()
+        config_path = config_dir / f"config-{socks_port}-{http_port}.json"
+
+        try:
+            # O_EXCL prevents symlink-plant attacks: the open() fails if the file already
+            # exists (including via a symlink). O_WRONLY | O_CREAT | O_TRUNC + 0600 perms.
+            fd = os.open(str(config_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            try:
+                if hasattr(os, "fchmod"):
+                    os.fchmod(fd, 0o600)
+                os.write(fd, json.dumps(config, indent=2).encode("utf-8"))
+            finally:
+                os.close(fd)
+        except OSError as error:
+            raise RuntimeError(f"could not write config file {config_path}: {error}")
+
+        log.debug("wrote config for %s to %s", server.label, config_path)
+        log_event(
+            "v2ray_spawn_start",
+            level="DEBUG",
+            message=f"Starting V2Ray subprocess for {server.label}",
+            context={
+                "binary": str(self.binary),
+                "config_path": str(config_path),
+                "socks_port": socks_port,
+                "http_port": http_port,
+                "server": server.label,
+                "protocol": server.protocol,
+                "address": server.address,
+                "port": server.port,
+                "country": server.country,
+            },
+        )
+
+        creationflags = 0
+        start_new_session = True
+        if os.name == "nt":
+            # Windows: CREATE_NO_WINDOW prevents a console popup. We deliberately do NOT
+            # use CREATE_NEW_PROCESS_GROUP — that would orphan the xray subprocess if the
+            # parent console is closed, because the child wouldn't receive the close event.
+            # Without it, the child dies alongside the parent when the console closes.
+            creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+            start_new_session = False
+
+        process = subprocess.Popen(
+            [str(self.binary), "run", "-c", str(config_path)],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            cwd=str(config_path.parent),
+            start_new_session=start_new_session,
+            creationflags=creationflags,
+            close_fds=True,
+        )
+
+        return {
+            "process": process,
+            "config_path": config_path,
+            "socks_port": socks_port,
+            "http_port": http_port,
+            "pid": process.pid,
+            "started_at": time.time(),
+            "verified": False,
+        }
+
+    @staticmethod
+    def _is_process_alive(info: dict) -> bool:
+        process: Optional[subprocess.Popen] = info.get("process")
+        if process is None:
+            return False
+        if process.poll() is not None:
+            return False
+        return True
+
+    def _wait_for_ready(self, socks_port: int, *, timeout: float) -> bool:
+        """Poll the SOCKS5 inbound until it accepts connections or the process exits.
+
+        Returns True if the port accepted a connection. Returns False if the process
+        exited or the timeout elapsed. When the process exits, its captured stderr
+        is stored in ``info["exit_output"]`` so the caller can include it in an error
+        message.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            info = next((i for i in self._active.values() if i.get("socks_port") == socks_port), None)
+            if info and not self._is_process_alive(info):
+                # Process died — capture its stderr for error reporting. communicate()
+                # is used instead of select() because select doesn't work on Windows
+                # pipes. Since the process is dead, communicate() returns immediately.
+                info["exit_output"] = self._read_dead_process_output(info)
+                return False
+            try:
+                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                    s.settimeout(0.5)
+                    s.connect((self.bind_host, socks_port))
+                    return True
+            except OSError:
+                time.sleep(0.2)
+        # Timed out — the process is still alive but the port never opened.
+        info = next((i for i in self._active.values() if i.get("socks_port") == socks_port), None)
+        if info:
+            info["exit_output"] = f"process still running (pid {info.get('pid')}) but port {socks_port} never accepted connections"
+        return False
+
+    @staticmethod
+    def _read_dead_process_output(info: dict) -> str:
+        """Read stderr from a process that has exited.
+
+        Uses :meth:`subprocess.Popen.communicate` which is cross-platform (unlike
+        ``select.select`` on pipes, which is Unix-only). Since the process is already
+        dead, ``communicate`` returns immediately at EOF.
+        """
+        process: Optional[subprocess.Popen] = info.get("process")
+        if process is None:
+            return ""
+        try:
+            _, stderr = process.communicate(timeout=2)
+            if stderr:
+                return stderr.decode("utf-8", errors="replace").strip()
+            return ""
+        except Exception:
+            return ""
+
+    def _verify_proxy(self, query_key: str, *, max_retries: int = 3) -> None:
+        """Confirm the spawned proxy exits in the expected country via get_ip_info."""
+        info = self._active.get(query_key)
+        if not info:
+            return
+        proxy_uri = self._build_proxy_uri(info["socks_port"], info["http_port"])
+        server: V2RayServer = info["server"]
+        expected_country = (server.country or "").upper()
+
+        session = requests.Session()
+        try:
+            session.proxies = {"http": proxy_uri, "https": proxy_uri}
+            last_error: Optional[str] = None
+            for attempt in range(max_retries):
+                try:
+                    ip_info = get_ip_info(session)
+                except Exception as error:
+                    last_error = str(error)
+                    ip_info = None
+
+                if ip_info:
+                    actual_country = (ip_info.get("country") or "").upper()
+                    info["verified"] = True
+                    info["public_ip"] = ip_info.get("ip")
+                    info["ip_country"] = actual_country
+                    info["ip_city"] = ip_info.get("city")
+                    info["ip_org"] = ip_info.get("org")
+
+                    log_event(
+                        "v2ray_verify_success",
+                        level="INFO",
+                        message=f"V2Ray proxy verified for {server.label}",
+                        context={
+                            "query": query_key,
+                            "server": server.label,
+                            "expected_country": expected_country or None,
+                            "actual_country": actual_country,
+                            "ip": ip_info.get("ip"),
+                            "city": ip_info.get("city"),
+                            "org": ip_info.get("org"),
+                            "attempts": attempt + 1,
+                        },
+                    )
+
+                    # If we have an expected country and it doesn't match, log a warning
+                    # but don't raise — the proxy may still be functional for the user's
+                    # purpose (e.g. CDN-based geofencing that doesn't strictly match the
+                    # exit IP's country).
+                    if expected_country and actual_country and actual_country != expected_country:
+                        log.warning(
+                            "country mismatch for %s — expected %s, got %s (IP: %s). "
+                            "The proxy is still returned; check your subscription if this is unexpected.",
+                            server.label, expected_country, actual_country, ip_info.get("ip"),
+                        )
+                    return
+
+                if attempt < max_retries - 1:
+                    time.sleep(2 ** attempt)
+        finally:
+            try:
+                session.close()
+            except Exception:
+                pass
+
+        log_event(
+            "v2ray_verify_failed",
+            level="WARNING",
+            message=f"V2Ray IP verification failed for {server.label} after {max_retries} attempts",
+            context={
+                "query": query_key,
+                "server": server.label,
+                "max_retries": max_retries,
+                "last_error": last_error,
+            },
+        )
+        # Don't raise — verification is best-effort. The proxy may still work.
+
+    def _build_proxy_uri(self, socks_port: int, http_port: int) -> str:
+        """Build the proxy URI returned to the caller, based on ``proxy_scheme``."""
+        if self.proxy_scheme in ("http", "https"):
+            return f"{self.proxy_scheme}://{self.bind_host}:{http_port}"
+        return f"{self.proxy_scheme}://{self.bind_host}:{socks_port}"
+
+    def _kill_process(self, info: dict) -> None:
+        """Terminate the subprocess, close its stderr pipe, and unlink the config file.
+
+        The config file is overwritten with zeros before unlinking (best-effort, like
+        Gluetun's env-file handling) because it contains server credentials.
+        """
+        process: Optional[subprocess.Popen] = info.get("process")
+        if process and process.poll() is None:
+            try:
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=5)
+            except Exception as error:
+                log.debug("error killing process %s: %s", info.get("pid"), error)
+
+        # Close stderr pipe so we don't leak FDs. The pipe handle lives on the Popen
+        # object (set via stderr=PIPE in _spawn_process), not on the info dict.
+        if process and process.stderr:
+            try:
+                process.stderr.close()
+            except Exception:
+                pass
+
+        config_path: Optional[Path] = info.get("config_path")
+        if config_path and config_path.is_file():
+            try:
+                # Best-effort secure delete: overwrite then unlink, like Gluetun does for
+                # its env files, since the config contains server credentials.
+                try:
+                    with open(config_path, "r+b") as f:
+                        f.seek(0, os.SEEK_END)
+                        length = f.tell()
+                        f.seek(0)
+                        if length > 0:
+                            f.write(b"\x00" * length)
+                            f.flush()
+                            os.fsync(f.fileno())
+                except Exception:
+                    pass
+                config_path.unlink()
+            except Exception:
+                pass
+
+    def cleanup(self) -> None:
+        """Stop every subprocess spawned by this provider instance."""
+        with self._port_lock:
+            items = list(self._active.items())
+            self._active.clear()
+        count = len(items)
+        for query_key, info in items:
+            self._kill_process(info)
+            log_event(
+                "v2ray_process_removed",
+                level="DEBUG",
+                message=f"Removed V2Ray subprocess for {query_key}",
+                context={"query": query_key, "pid": info.get("pid")},
+            )
+        if count:
+            log_event(
+                "v2ray_cleanup_complete",
+                level="INFO",
+                message=f"V2Ray cleanup complete: removed {count} subprocess(es)",
+                context={"count": count},
+            )
+
+    def __del__(self) -> None:
+        if getattr(self, "auto_cleanup", True):
+            try:
+                self.cleanup()
+            except Exception:
+                pass
+
+    # -- Introspection (used by tests + useful for debugging) --------------
+
+    @property
+    def servers(self) -> list[V2RayServer]:
+        """Read-only view of the flat server pool (subscription / config_path / servers)."""
+        return list(self._servers)
+
+    @property
+    def country_servers(self) -> dict[str, list[V2RayServer]]:
+        """Read-only view of the per-country server map (the ``countries:`` YAML block)."""
+        return {k: list(v) for k, v in self._country_servers.items()}
+
+    def last_connection_display(self) -> Optional[str]:
+        """Return a short display string for the most recent connection.
+
+        Used by ``dl.py`` to show a human-readable summary instead of the raw proxy URI.
+        Format: ``(server_label) exit_ip`` — e.g. ``(🇺🇸 US - Los Angeles) 216.185.57.75``.
+        Returns None if no connection has been made yet, in which case the caller falls
+        back to printing the raw proxy URI.
+
+        This deliberately does NOT implement ``get_connection_info`` (which would make
+        ``dl.py`` print "VPN Connected: ..." — misleading for a proxy, not a VPN).
+        """
+        info = self._last_connection
+        if not info:
+            return None
+        server: Optional[V2RayServer] = info.get("server")
+        if not server:
+            return None
+        ip = info.get("public_ip", "")
+        label = server.label
+        if ip:
+            return f"({label}) {ip}"
+        return f"({label})"


### PR DESCRIPTION
## Summary

Adds a new V2Ray / Xray proxy provider that spawns a local subprocess with an ephemeral SOCKS5 inbound on `127.0.0.1`, routing traffic through VMess / VLESS / Trojan / Shadowsocks outbounds. Works alongside the existing NordVPN, ExpressVPN, ProtonVPN, SurfsharkVPN, WindscribeVPN, Hola, Gluetun, and Basic proxy providers.

This is a replacement for #133 which was accidentally closed when the branch was force-pushed with a broken git history. The branch has been recreated cleanly on top of the latest `dev`.

## Server sources (all coexist)

- `subscription_url` — base64/plain subscription endpoint(s)
- `config_path` — pre-built V2Ray/Xray JSON config file
- `servers` — inline list of `vmess://` / `vless://` / `trojan://` / `ss://` URIs
- `countries` — basic-style per-country URI map (like the `Basic` provider)

Plus a **direct-URI CLI mode**: `--proxy v2ray:vmess://...` spawns a one-shot subprocess for that exact URI. V2Ray is **config-gated**: a `v2ray:` block (even an empty `{}`) is required to opt in.

## Changes from previous PR (#133)

All issues from the code review on #133 have been addressed:

1. **`allowInsecure` default** — TLS verification now defaults to ON. Only set when `verify_cert: false` is explicitly in the share link.
2. **PIPE buffer deadlock** — `stdout` is now `DEVNULL`; `stderr` stays PIPE but is only read via `communicate()` after process exit.
3. **Symlink-plant/clobber** — Each instance gets its own `tempfile.mkdtemp()` dir; config files use `O_EXCL`.
4. **Rebase** — Done against current `dev`. Docs rewritten for the new MkDocs Material structure.
5. **Config-gated** — V2Ray requires a `v2ray:` block (per maintainer preference).
6. **Dead-cached-process** — Now kills/cleans old entry before spawning.
7. **Port allocation race** — `_spawn_for_server` holds `_port_lock` across allocate-spawn-store.
8. **`bind_host`** — Now flows through to `build_config()` (was hardcoded to `127.0.0.1`).
9. **Credential redaction** — Uses the framework's `redact_text()` from `unshackle.core.utils.redact`.
10. **Hand-rolled cache** — Removed entirely.
11. **Subscription fetch** — Deferred to first `get_proxy()` call.
12. **Country detection** — Uses dynamic pycountry lookup (all 249 countries via `name`, `common_name`, `official_name`) instead of a hardcoded list.
13. **Duplicate `_redact_uri`** — Replaced with the framework's existing `redact_text()`.
14. **Dead `\buk\b` regex** — Removed (already caught by `COUNTRY_CODE_ALIASES` + 2-letter hint path).

## Bug fix included

Fixes a pre-existing bug in the provider-prefix regex (`^[a-z]+:.+$` → `^[a-z][a-z0-9]*:.+$`) that prevented provider names containing digits (like `v2ray`) from being recognised in `dl.py`, `search.py`, and `resolve.py`.

## Testing

- 579 tests pass (134 new V2Ray + 445 existing), 0 failures
- `ruff` + `isort` clean
- No new runtime dependencies

## Live testing

Free temporary V2Ray servers for end-to-end testing are available at https://www.vpnjantit.com/ — they offer free vmess/vless/trojan/shadowsocks servers that rotate hourly.

## Files

**New:**
- `unshackle/core/proxies/v2ray.py` — the provider
- `tests/core/test_v2ray.py` — 134 unit tests

**Modified (additive, no breaking changes):**
- `unshackle/core/binaries.py` — Xray + V2Ray binary discovery
- `unshackle/core/proxies/__init__.py` — registered V2Ray
- `unshackle/core/proxies/resolve.py` — wired V2Ray + fixed regex + config-gated load
- `unshackle/commands/dl.py` — V2Ray loading + fixed regex + direct-URI handling
- `unshackle/commands/search.py` — same as dl.py
- `unshackle/commands/env.py` — xray/v2ray in `env check` dependencies
- `docs/guide/proxies-and-vpn.md` — V2Ray section
- `docs/reference/configuration.md` — V2Ray in provider table