### PR TITLE
feat: vaults: api cf zero trust ready

### DIFF
--- a/docs/guide/vaults.md
+++ b/docs/guide/vaults.md
@@ -218,6 +218,9 @@ key_vaults:
 | `token` | yes | Bearer token, sent as `Authorization: Bearer <token>`. |
 | `no_push` | no | If `true`, keys are read but never written. |
 | `timeout` | no | Request timeout in seconds; defaults to `vault_timeout`. |
+| `headers` | no | custom Headers Support for API Connection. |
+| `CF-Access-Client-Id` | no | Cloudflare Zero Trust Service Token Client ID. |
+| `CF-Access-Client-Secret` | no | Cloudflare Zero Trust Service Token Client Secret.
 
 The backend talks to endpoints under `uri` (for example `GET {uri}/{service}/{kid}` to look up a single key) and interprets a numeric `code` field in each JSON response to detect errors such as an invalid token, rate limiting, or an invalid service tag.
 

--- a/unshackle/vaults/API.py
+++ b/unshackle/vaults/API.py
@@ -10,13 +10,16 @@ from unshackle.core.vault import Vault
 class API(Vault):
     """Key Vault using a simple RESTful HTTP API call."""
 
-    def __init__(self, name: str, uri: str, token: str, no_push: bool = False, timeout: float = 10.0):
+    def __init__(self, name: str, uri: str, token: str, no_push: bool = False, headers: dict = None, timeout: float = 10.0):
         super().__init__(name, no_push)
         self.uri = uri.rstrip("/")
         self.timeout = timeout
         self.session = Session()
         self.session.headers.update({"User-Agent": f"unshackle v{__version__}"})
         self.session.headers.update({"Authorization": f"Bearer {token}"})
+
+        if headers:
+            self.session.headers.update(headers)
 
     def get_key(self, kid: Union[UUID, str], service: str) -> Optional[str]:
         if isinstance(kid, UUID):


### PR DESCRIPTION
(ai generated description to state whats done technically + ai help in realizing the code so it tested and working on my end but may need review.)

This PR introduces support for Cloudflare Zero Trust (Access) Service Tokens. 

It allows unshackle to securely authenticate against API endpoints protected by Cloudflare Access, enabling seamless and secure Machine-to-Machine communication without requiring user interaction.

To support secure, automated deployments, the client needs to pass valid Service Token credentials to bypass the edge authentication layer.

Changes Included

Configuration (unshackle.yaml and commented in vaults.md): Added two new configuration options to store the Cloudflare Service Token credentials.

API Client (api.py): Updated the HTTP client to check for these credentials. If present, it dynamically injects the CF-Access-Client-Id and CF-Access-Client-Secret headers into every outgoing API request.