### PR TITLE
feat(vaults): support custom headers on API vault

### DIFF
--- a/docs/guide/vaults.md
+++ b/docs/guide/vaults.md
@@ -209,7 +209,7 @@ key_vaults:
     uri: https://vault.example.com/api
     token: "your-bearer-token"
     headers:
-      CF-Access-Client-Id: "CLIENTCLIENT_ID_HERE"
+      CF-Access-Client-Id: "CLIENT_ID_HERE"
       CF-Access-Client-Secret: "CLIENT_SECRET_HERE"
 ```
 
@@ -221,9 +221,7 @@ key_vaults:
 | `token` | yes | Bearer token, sent as `Authorization: Bearer <token>`. |
 | `no_push` | no | If `true`, keys are read but never written. |
 | `timeout` | no | Request timeout in seconds; defaults to `vault_timeout`. |
-| `headers` | no | custom Headers for API Connection. |
-| `CF-Access-Client-Id` | no | Cloudflare Zero Trust Service Token Client ID. |
-| `CF-Access-Client-Secret` | no | Cloudflare Zero Trust Service Token Client Secret.
+| `headers` | no | Extra HTTP `headers` sent with every request, for example the Cloudflare Access service-token headers `CF-Access-Client-Id` and `CF-Access-Client-Secret`. |
 
 The backend talks to endpoints under `uri` (for example `GET {uri}/{service}/{kid}` to look up a single key) and interprets a numeric `code` field in each JSON response to detect errors such as an invalid token, rate limiting, or an invalid service tag.
 

--- a/docs/guide/vaults.md
+++ b/docs/guide/vaults.md
@@ -208,6 +208,9 @@ key_vaults:
     name: myapi
     uri: https://vault.example.com/api
     token: "your-bearer-token"
+    headers:
+      CF-Access-Client-Id: "CLIENTCLIENT_ID_HERE"
+      CF-Access-Client-Secret: "CLIENT_SECRET_HERE"
 ```
 
 | Field | Required | Description |
@@ -218,6 +221,9 @@ key_vaults:
 | `token` | yes | Bearer token, sent as `Authorization: Bearer <token>`. |
 | `no_push` | no | If `true`, keys are read but never written. |
 | `timeout` | no | Request timeout in seconds; defaults to `vault_timeout`. |
+| `headers` | no | custom Headers for API Connection. |
+| `CF-Access-Client-Id` | no | Cloudflare Zero Trust Service Token Client ID. |
+| `CF-Access-Client-Secret` | no | Cloudflare Zero Trust Service Token Client Secret.
 
 The backend talks to endpoints under `uri` (for example `GET {uri}/{service}/{kid}` to look up a single key) and interprets a numeric `code` field in each JSON response to detect errors such as an invalid token, rate limiting, or an invalid service tag.
 

--- a/unshackle/vaults/API.py
+++ b/unshackle/vaults/API.py
@@ -10,13 +10,16 @@ from unshackle.core.vault import Vault
 class API(Vault):
     """Key Vault using a simple RESTful HTTP API call."""
 
-    def __init__(self, name: str, uri: str, token: str, no_push: bool = False, timeout: float = 10.0):
+    def __init__(self, name: str, uri: str, token: str, no_push: bool = False, headers: dict = None, timeout: float = 10.0):
         super().__init__(name, no_push)
         self.uri = uri.rstrip("/")
         self.timeout = timeout
         self.session = Session()
         self.session.headers.update({"User-Agent": f"unshackle v{__version__}"})
         self.session.headers.update({"Authorization": f"Bearer {token}"})
+
+        if headers:
+            self.session.headers.update(headers)
 
     def get_key(self, kid: Union[UUID, str], service: str) -> Optional[str]:
         if isinstance(kid, UUID):

--- a/unshackle/vaults/API.py
+++ b/unshackle/vaults/API.py
@@ -10,7 +10,7 @@ from unshackle.core.vault import Vault
 class API(Vault):
     """Key Vault using a simple RESTful HTTP API call."""
 
-    def __init__(self, name: str, uri: str, token: str, no_push: bool = False, headers: dict = None, timeout: float = 10.0):
+    def __init__(self, name: str, uri: str, token: str, no_push: bool = False, headers: Optional[dict[str, str]] = None, timeout: float = 10.0):
         super().__init__(name, no_push)
         self.uri = uri.rstrip("/")
         self.timeout = timeout
@@ -25,9 +25,14 @@ class API(Vault):
         if isinstance(kid, UUID):
             kid = kid.hex
 
-        data = self.session.get(
-            url=f"{self.uri}/{service.lower()}/{kid}", headers={"Accept": "application/json"}, timeout=self.timeout
-        ).json()
+        response = self.session.get(
+            url=f"{self.uri}/{service.lower()}/{kid}",
+            headers={"Accept": "application/json"},
+            timeout=self.timeout,
+            allow_redirects=False
+        )
+        response.raise_for_status()
+        data = response.json()
 
         code = int(data.get("code", 0))
         message = data.get("message")
@@ -55,12 +60,15 @@ class API(Vault):
         page = 1
 
         while True:
-            data = self.session.get(
+            response = self.session.get(
                 url=f"{self.uri}/{service.lower()}",
                 params={"page": page, "total": 10},
                 headers={"Accept": "application/json"},
                 timeout=self.timeout,
-            ).json()
+                allow_redirects=False
+            )
+            response.raise_for_status()
+            data = response.json()
 
             code = int(data.get("code", 0))
             message = data.get("message")
@@ -93,12 +101,15 @@ class API(Vault):
         if isinstance(kid, UUID):
             kid = kid.hex
 
-        data = self.session.post(
+        response = self.session.post(
             url=f"{self.uri}/{service.lower()}/{kid}",
             json={"content_key": key},
             headers={"Accept": "application/json"},
             timeout=self.timeout,
-        ).json()
+            allow_redirects=False
+        )
+        response.raise_for_status()
+        data = response.json()
 
         code = int(data.get("code", 0))
         message = data.get("message")
@@ -144,6 +155,7 @@ class API(Vault):
                     json={"content_keys": batch_keys},
                     headers={"Accept": "application/json"},
                     timeout=self.timeout,
+                    allow_redirects=False
                 )
 
                 # Check for HTTP errors that suggest batch is too large
@@ -153,7 +165,8 @@ class API(Vault):
                     else:
                         batch_size = 1
                     continue
-
+                
+                response.raise_for_status()
                 data = response.json()
             except Exception:
                 # JSON decode error or connection issue - try smaller batch
@@ -190,7 +203,14 @@ class API(Vault):
         return total_added
 
     def get_services(self) -> Iterator[str]:
-        data = self.session.post(url=self.uri, headers={"Accept": "application/json"}, timeout=self.timeout).json()
+        response = self.session.post(
+            url=self.uri,
+            headers={"Accept": "application/json"},
+            timeout=self.timeout,
+            allow_redirects=False
+        )
+        response.raise_for_status()
+        data = response.json()
 
         code = int(data.get("code", 0))
         message = data.get("message")
@@ -230,3 +250,4 @@ class Exceptions:
 
     class ContentKeyInvalid(Exception):
         """The Content Key is invalid."""
+        


### PR DESCRIPTION
(ai generated description to state whats done technically + ai help in realizing the code so it tested and working on my end but may need review.)

## Summary
This PR introduces the ability to define custom HTTP headers for the `API` vault backend directly via the configuration file. 

By implementing a generic `headers` dictionary, users can now pass custom authentication tokens, metadata, or routing headers to upstream services. This allows the `API` vault to sit securely behind reverse proxies, API gateways, or Zero Trust network solutions (such as Cloudflare Access) without requiring any vendor-specific hardcoding in the unshackle core.

## Key Changes
* **Custom Headers Configuration:** Added an optional `headers: dict[str, str]` parameter to the `API` vault initialization, which updates the `requests.Session` headers.
* **Security / Prevent Header Leakage:** Added `allow_redirects=False` to all HTTP requests. This prevents sensitive custom headers (like service tokens or API secrets) from being unintentionally leaked to third-party domains in the event of an unexpected HTTP redirect.
* **Robust Error Handling:** Added `response.raise_for_status()` prior to `.json()` parsing. This ensures that network-level rejections from gateways or proxies (e.g., a `403 Forbidden` HTML page) are caught and raised as proper HTTP errors, rather than resulting in obscure `JSONDecodeError`s.
* **Documentation:** Updated `vaults.md` to document the new `headers` field, including a practical YAML example for Machine-to-Machine (M2M) authentication.